### PR TITLE
feat: "Show Decorations" toggle in settings menu

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -815,46 +815,55 @@ class _MyAppState extends State<MyApp>
                     final shellMediaQuery = mediaQuery.copyWith(
                       size: shellSize,
                     );
-                    return Container(
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          begin: Alignment.topCenter,
-                          end: Alignment.bottomCenter,
-                          colors: [
-                            BracuPalette.bgTop(context),
-                            BracuPalette.bgBottom(context),
-                          ],
-                        ),
-                      ),
-                      child: Center(
-                        child: Container(
-                          width: shellWidth,
-                          height: shellHeight,
-                          margin: const EdgeInsets.symmetric(vertical: 0),
-                          decoration: BoxDecoration(
-                            color: Theme.of(context).scaffoldBackgroundColor,
-                            borderRadius: BorderRadius.circular(
-                              kIsWeb ? 32 : 0,
+                    return ValueListenableBuilder(
+                      valueListenable: HomeCardPreferences.decorationNotifier,
+                      builder: (context, decorationsEnabled, child) {
+                        return Container(
+                          decoration: decorationsEnabled
+                              ? BoxDecoration(
+                                  gradient: LinearGradient(
+                                    begin: Alignment.topCenter,
+                                    end: Alignment.bottomCenter,
+                                    colors: [
+                                      BracuPalette.bgTop(context),
+                                      BracuPalette.bgBottom(context),
+                                    ],
+                                  ),
+                                )
+                              : null,
+                          child: Center(
+                            child: Container(
+                              width: shellWidth,
+                              height: shellHeight,
+                              margin: const EdgeInsets.symmetric(vertical: 0),
+                              decoration: BoxDecoration(
+                                color: Theme.of(
+                                  context,
+                                ).scaffoldBackgroundColor,
+                                borderRadius: BorderRadius.circular(
+                                  kIsWeb ? 32 : 0,
+                                ),
+                                boxShadow: kIsWeb
+                                    ? [
+                                        BoxShadow(
+                                          color: Colors.black.withValues(
+                                            alpha: 0.16,
+                                          ),
+                                          blurRadius: 30,
+                                          offset: const Offset(0, 16),
+                                        ),
+                                      ]
+                                    : null,
+                              ),
+                              clipBehavior: Clip.antiAlias,
+                              child: MediaQuery(
+                                data: shellMediaQuery,
+                                child: content,
+                              ),
                             ),
-                            boxShadow: kIsWeb
-                                ? [
-                                    BoxShadow(
-                                      color: Colors.black.withValues(
-                                        alpha: 0.16,
-                                      ),
-                                      blurRadius: 30,
-                                      offset: const Offset(0, 16),
-                                    ),
-                                  ]
-                                : null,
                           ),
-                          clipBehavior: Clip.antiAlias,
-                          child: MediaQuery(
-                            data: shellMediaQuery,
-                            child: content,
-                          ),
-                        ),
-                      ),
+                        );
+                      },
                     );
                   },
                 ),

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -880,6 +880,7 @@ class _HomeData {
             showQuickAccessSection:
                 visibilityJson['showQuickAccessSection'] == true,
             showRamadanCard: visibilityJson['showRamadanCard'] == true,
+            showDecorations: visibilityJson['showDecorations'] == true,
             showTodaySchedule: visibilityJson['showTodaySchedule'] == true,
             showExamCountdownCard:
                 visibilityJson['showExamCountdownCard'] == true,

--- a/lib/pages/home_sections/home_dashboard_data.dart
+++ b/lib/pages/home_sections/home_dashboard_data.dart
@@ -25,6 +25,7 @@ class _HomeDashboardState extends State<_HomeDashboard> with RefreshBusState {
   bool _autoOpenedWifiAssistant = false;
   bool _isOpeningWifiAssistant = false;
   bool _isAutoExtendingSession = false;
+  bool _showBlobs = true;
   DateTime? _lastAutoAssistantOpenAt;
   DateTime? _lastAutoSessionExtendAt;
   Timer? _captiveAutoTimer;
@@ -47,6 +48,9 @@ class _HomeDashboardState extends State<_HomeDashboard> with RefreshBusState {
   @override
   void initState() {
     super.initState();
+    AppStorage.instance.getBool("showdecorblobs").then((value) {
+      if (mounted) setState(() => _showBlobs = value ?? true);
+    });
     final forceRefresh = isRefreshingFrom('auth');
     if (forceRefresh) {
       _cachedData = null;

--- a/lib/pages/home_sections/home_dashboard_data.dart
+++ b/lib/pages/home_sections/home_dashboard_data.dart
@@ -25,7 +25,6 @@ class _HomeDashboardState extends State<_HomeDashboard> with RefreshBusState {
   bool _autoOpenedWifiAssistant = false;
   bool _isOpeningWifiAssistant = false;
   bool _isAutoExtendingSession = false;
-  bool _showBlobs = true;
   DateTime? _lastAutoAssistantOpenAt;
   DateTime? _lastAutoSessionExtendAt;
   Timer? _captiveAutoTimer;
@@ -48,9 +47,7 @@ class _HomeDashboardState extends State<_HomeDashboard> with RefreshBusState {
   @override
   void initState() {
     super.initState();
-    AppStorage.instance.getBool("showdecorblobs").then((value) {
-      if (mounted) setState(() => _showBlobs = value ?? true);
-    });
+
     final forceRefresh = isRefreshingFrom('auth');
     if (forceRefresh) {
       _cachedData = null;

--- a/lib/pages/home_sections/home_dashboard_view.dart
+++ b/lib/pages/home_sections/home_dashboard_view.dart
@@ -5,6 +5,7 @@ extension _HomeDashboardView on _HomeDashboardState {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bgTop = isDark ? Colors.black : _HomeDashboardState._bgTop;
     final bgBottom = isDark ? Colors.black : _HomeDashboardState._bgBottom;
+
     return Container(
       decoration: BoxDecoration(
         gradient: LinearGradient(
@@ -16,22 +17,24 @@ extension _HomeDashboardView on _HomeDashboardState {
       child: SafeArea(
         child: Stack(
           children: [
-            Positioned(
-              top: -80,
-              right: -60,
-              child: DecorBlob(
-                color: _HomeDashboardState._primary.withValues(alpha: 0.12),
-                size: 200,
+            if (_showBlobs)
+              Positioned(
+                top: -80,
+                right: -60,
+                child: DecorBlob(
+                  color: _HomeDashboardState._primary.withValues(alpha: 0.12),
+                  size: 200,
+                ),
               ),
-            ),
-            Positioned(
-              bottom: -90,
-              left: -70,
-              child: DecorBlob(
-                color: _HomeDashboardState._accent.withValues(alpha: 0.10),
-                size: 220,
+            if (_showBlobs)
+              Positioned(
+                bottom: -90,
+                left: -70,
+                child: DecorBlob(
+                  color: _HomeDashboardState._accent.withValues(alpha: 0.10),
+                  size: 220,
+                ),
               ),
-            ),
             Column(
               children: [
                 Expanded(

--- a/lib/pages/home_sections/home_dashboard_view.dart
+++ b/lib/pages/home_sections/home_dashboard_view.dart
@@ -5,511 +5,547 @@ extension _HomeDashboardView on _HomeDashboardState {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bgTop = isDark ? Colors.black : _HomeDashboardState._bgTop;
     final bgBottom = isDark ? Colors.black : _HomeDashboardState._bgBottom;
-    final showBlobs = _latestData?.cardVisibility.showDecorations ?? true;
 
-    return Container(
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [bgTop, bgBottom],
-        ),
-      ),
-      child: SafeArea(
-        child: Stack(
-          children: [
-            if (showBlobs)
-              Positioned(
-                top: -80,
-                right: -60,
-                child: DecorBlob(
-                  color: _HomeDashboardState._primary.withValues(alpha: 0.12),
-                  size: 200,
-                ),
-              ),
-            if (showBlobs)
-              Positioned(
-                bottom: -90,
-                left: -70,
-                child: DecorBlob(
-                  color: _HomeDashboardState._accent.withValues(alpha: 0.10),
-                  size: 220,
-                ),
-              ),
-            Column(
+    return ValueListenableBuilder(
+      valueListenable: HomeCardPreferences.decorationNotifier,
+      builder: (context, decorationsEnabled, child) {
+        return Container(
+          decoration: decorationsEnabled
+              ? BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [bgTop, bgBottom],
+                  ),
+                )
+              : null,
+          child: SafeArea(
+            child: Stack(
               children: [
-                Expanded(
-                  child: FutureBuilder<_HomeData>(
-                    future: _future,
-                    builder: (context, snapshot) {
-                      final data = _latestData ?? snapshot.data;
-                      final isLoading =
-                          snapshot.connectionState == ConnectionState.waiting &&
-                          data == null;
-                      if (isLoading) {
-                        return BracuRefreshScroll(
-                          onRefresh: _handleRefresh,
-                          showScrollTopButton: false,
-                          padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
-                          child: _HomeDashboardLoadingShell(
-                            onOpenSupport: () =>
-                                showBracuFundingSupportSheet(context),
-                            onOpenSettings: () =>
-                                widget.onNavigate(HomeTab.settings),
-                            onLogout: widget.onLogout,
-                          ),
-                        );
-                      }
-
-                      final profile =
-                          data?.profile ?? const <String, String?>{};
-                      final photoUrl = data?.photoUrl;
-                      final ramadan =
-                          data?.ramadan ??
-                          const RamadanStatus(isRamadan: false);
-                      final isRamadan = ramadan.isRamadan;
-                      final nextCountdownTarget = _nextRamadanTarget(
-                        sehri: ramadan.sehriEndsAt,
-                        iftar: ramadan.iftarAt,
-                      );
-                      final holidayStatus =
-                          data?.holiday ?? HolidayStatus.empty;
-                      final cardVisibility =
-                          data?.cardVisibility ?? HomeCardPreferences.defaults;
-                      final isTodayHoliday = holidayStatus.isTodayHoliday;
-                      final today = _todayName();
-                      final todayDate = DateFormat(
-                        'd MMMM, yyyy',
-                      ).format(DateTime.now());
-                      final todayEntries =
-                          (data?.entries ?? [])
-                              .where(
-                                (e) =>
-                                    normalizeWeekday(e.day) ==
-                                    normalizeWeekday(today),
-                              )
-                              .toList()
-                            ..sort(
-                              (a, b) =>
-                                  _timeToMinutes(a.startTime) -
-                                  _timeToMinutes(b.startTime),
+                if (decorationsEnabled)
+                  Positioned(
+                    top: -80,
+                    right: -60,
+                    child: DecorBlob(
+                      color: _HomeDashboardState._primary.withValues(
+                        alpha: 0.12,
+                      ),
+                      size: 200,
+                    ),
+                  ),
+                if (decorationsEnabled)
+                  Positioned(
+                    bottom: -90,
+                    left: -70,
+                    child: DecorBlob(
+                      color: _HomeDashboardState._accent.withValues(
+                        alpha: 0.10,
+                      ),
+                      size: 220,
+                    ),
+                  ),
+                Column(
+                  children: [
+                    Expanded(
+                      child: FutureBuilder<_HomeData>(
+                        future: _future,
+                        builder: (context, snapshot) {
+                          final data = _latestData ?? snapshot.data;
+                          final isLoading =
+                              snapshot.connectionState ==
+                                  ConnectionState.waiting &&
+                              data == null;
+                          if (isLoading) {
+                            return BracuRefreshScroll(
+                              onRefresh: _handleRefresh,
+                              showScrollTopButton: false,
+                              padding: const EdgeInsets.fromLTRB(
+                                20,
+                                16,
+                                20,
+                                28,
+                              ),
+                              child: _HomeDashboardLoadingShell(
+                                onOpenSupport: () =>
+                                    showBracuFundingSupportSheet(context),
+                                onOpenSettings: () =>
+                                    widget.onNavigate(HomeTab.settings),
+                                onLogout: widget.onLogout,
+                              ),
                             );
-                      final examWeekStatus = _todayExamWeekStatus(
-                        data?.sections ?? const <section.Section>[],
-                        data?.examOverrides ??
-                            const <String, ExamScheduleOverride>{},
-                      );
-                      final isExamWeekActive = examWeekStatus.isActive;
-                      final nextCountdown = _nextDeadlineCountdown(
-                        data?.sections ?? const <section.Section>[],
-                        data?.examOverrides ??
-                            const <String, ExamScheduleOverride>{},
-                        data?.personalSchedules ?? const <CustomSchedule>[],
-                      );
-                      final todayExams = _todayExamEntries(
-                        data?.sections ?? const <section.Section>[],
-                        data?.examOverrides ??
-                            const <String, ExamScheduleOverride>{},
-                      );
-                      final visibleEntries = isTodayHoliday
-                          ? <_ScheduleEntry>[]
-                          : (todayExams.isNotEmpty || isExamWeekActive
-                                ? <_ScheduleEntry>[]
-                                : todayEntries);
-                      return BracuRefreshScroll(
-                        onRefresh: _handleRefresh,
-                        showScrollTopButton: false,
-                        padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            _TopBar(
-                              name: profile['fullName'] ?? 'BRACU Student',
-                              photoUrl: photoUrl,
-                              onOpenNotifications: () =>
-                                  widget.onNavigate(HomeTab.notifications),
-                              onProfileTap: () =>
-                                  widget.onNavigate(HomeTab.profile),
-                            ),
-                            if (_captiveStatus?.state ==
-                                CaptiveWifiState.captive) ...[
-                              const SizedBox(height: 12),
-                              _CaptiveWifiBanner(
-                                statusCode: _captiveStatus?.httpStatusCode,
-                                onOpenLogin: _openWifiLoginAssistant,
-                              ),
-                            ],
-                            const SizedBox(height: 18),
-                            StudentOverviewCard(
-                              studentId: profile['studentId'] ?? '',
-                              shortCode: profile['shortCode'] ?? '',
-                              department: profile['departmentName'] ?? '',
-                              currentSemester: profile['currentSemester'] ?? '',
-                              currentSessionSemesterId:
-                                  profile['currentSessionSemesterId'] ?? '',
-                              onOpenSupport: () =>
-                                  showBracuFundingSupportSheet(context),
-                              onOpenSettings: () =>
-                                  widget.onNavigate(HomeTab.settings),
-                              onLogout: widget.onLogout,
-                              countdown:
-                                  !cardVisibility.showExamCountdownCard ||
-                                      nextCountdown == null
-                                  ? null
-                                  : InkWell(
-                                      borderRadius: BorderRadius.circular(18),
-                                      onTap: () =>
-                                          widget.onNavigate(nextCountdown.tab),
-                                      child: ExamCountdownCard(
-                                        title: nextCountdown.title,
-                                        targetDateTime:
-                                            nextCountdown.targetDateTime,
-                                      ),
-                                    ),
-                            ),
-                            if (cardVisibility.showTodaySchedule) ...[
-                              const SizedBox(height: 12),
-                              InkWell(
-                                onTap: () => widget.onNavigate(
-                                  (todayExams.isNotEmpty || isExamWeekActive)
-                                      ? HomeTab.examSchedule
-                                      : HomeTab.studentSchedule,
+                          }
+
+                          final profile =
+                              data?.profile ?? const <String, String?>{};
+                          final photoUrl = data?.photoUrl;
+                          final ramadan =
+                              data?.ramadan ??
+                              const RamadanStatus(isRamadan: false);
+                          final isRamadan = ramadan.isRamadan;
+                          final nextCountdownTarget = _nextRamadanTarget(
+                            sehri: ramadan.sehriEndsAt,
+                            iftar: ramadan.iftarAt,
+                          );
+                          final holidayStatus =
+                              data?.holiday ?? HolidayStatus.empty;
+                          final cardVisibility =
+                              data?.cardVisibility ??
+                              HomeCardPreferences.defaults;
+                          final isTodayHoliday = holidayStatus.isTodayHoliday;
+                          final today = _todayName();
+                          final todayDate = DateFormat(
+                            'd MMMM, yyyy',
+                          ).format(DateTime.now());
+                          final todayEntries =
+                              (data?.entries ?? [])
+                                  .where(
+                                    (e) =>
+                                        normalizeWeekday(e.day) ==
+                                        normalizeWeekday(today),
+                                  )
+                                  .toList()
+                                ..sort(
+                                  (a, b) =>
+                                      _timeToMinutes(a.startTime) -
+                                      _timeToMinutes(b.startTime),
+                                );
+                          final examWeekStatus = _todayExamWeekStatus(
+                            data?.sections ?? const <section.Section>[],
+                            data?.examOverrides ??
+                                const <String, ExamScheduleOverride>{},
+                          );
+                          final isExamWeekActive = examWeekStatus.isActive;
+                          final nextCountdown = _nextDeadlineCountdown(
+                            data?.sections ?? const <section.Section>[],
+                            data?.examOverrides ??
+                                const <String, ExamScheduleOverride>{},
+                            data?.personalSchedules ?? const <CustomSchedule>[],
+                          );
+                          final todayExams = _todayExamEntries(
+                            data?.sections ?? const <section.Section>[],
+                            data?.examOverrides ??
+                                const <String, ExamScheduleOverride>{},
+                          );
+                          final visibleEntries = isTodayHoliday
+                              ? <_ScheduleEntry>[]
+                              : (todayExams.isNotEmpty || isExamWeekActive
+                                    ? <_ScheduleEntry>[]
+                                    : todayEntries);
+                          return BracuRefreshScroll(
+                            onRefresh: _handleRefresh,
+                            showScrollTopButton: false,
+                            padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                _TopBar(
+                                  name: profile['fullName'] ?? 'BRACU Student',
+                                  photoUrl: photoUrl,
+                                  onOpenNotifications: () =>
+                                      widget.onNavigate(HomeTab.notifications),
+                                  onProfileTap: () =>
+                                      widget.onNavigate(HomeTab.profile),
                                 ),
-                                child: Row(
-                                  children: [
-                                    Expanded(
-                                      child: Text(
-                                        'Today is $today',
-                                        style: TextStyle(
-                                          fontSize: 16,
-                                          fontWeight: FontWeight.w600,
-                                          color: BracuPalette.textPrimary(
-                                            context,
+                                if (_captiveStatus?.state ==
+                                    CaptiveWifiState.captive) ...[
+                                  const SizedBox(height: 12),
+                                  _CaptiveWifiBanner(
+                                    statusCode: _captiveStatus?.httpStatusCode,
+                                    onOpenLogin: _openWifiLoginAssistant,
+                                  ),
+                                ],
+                                const SizedBox(height: 18),
+                                StudentOverviewCard(
+                                  studentId: profile['studentId'] ?? '',
+                                  shortCode: profile['shortCode'] ?? '',
+                                  department: profile['departmentName'] ?? '',
+                                  currentSemester:
+                                      profile['currentSemester'] ?? '',
+                                  currentSessionSemesterId:
+                                      profile['currentSessionSemesterId'] ?? '',
+                                  onOpenSupport: () =>
+                                      showBracuFundingSupportSheet(context),
+                                  onOpenSettings: () =>
+                                      widget.onNavigate(HomeTab.settings),
+                                  onLogout: widget.onLogout,
+                                  countdown:
+                                      !cardVisibility.showExamCountdownCard ||
+                                          nextCountdown == null
+                                      ? null
+                                      : InkWell(
+                                          borderRadius: BorderRadius.circular(
+                                            18,
                                           ),
-                                        ),
-                                      ),
-                                    ),
-                                    Text(
-                                      todayDate,
-                                      style: TextStyle(
-                                        fontSize: 16,
-                                        fontWeight: FontWeight.w600,
-                                        color: BracuPalette.textPrimary(
-                                          context,
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              const SizedBox(height: 12),
-                              if (todayExams.isNotEmpty)
-                                ...todayExams
-                                    .take(3)
-                                    .map(
-                                      (exam) => Padding(
-                                        padding: const EdgeInsets.only(
-                                          bottom: 10,
-                                        ),
-                                        child: InkWell(
                                           onTap: () => widget.onNavigate(
-                                            HomeTab.examSchedule,
+                                            nextCountdown.tab,
                                           ),
-                                          child: _ScheduleTile(
-                                            title:
-                                                '${exam.courseCode} ${exam.type}',
-                                            subtitle: formatTimeRange(
-                                              exam.startTime,
-                                              exam.endTime,
-                                            ),
-                                            trailing: exam.room,
-                                            trailingSub: exam.faculties,
-                                            badge: formatSectionBadge(
-                                              exam.sectionName,
-                                            ),
-                                            color: _HomeDashboardState._accent,
-                                            isHighlighted: false,
+                                          child: ExamCountdownCard(
+                                            title: nextCountdown.title,
+                                            targetDateTime:
+                                                nextCountdown.targetDateTime,
                                           ),
                                         ),
-                                      ),
-                                    ),
-                              if (todayExams.isNotEmpty &&
-                                  visibleEntries.isNotEmpty)
-                                const SizedBox(height: 10),
-                              if (todayExams.isEmpty &&
-                                  (isTodayHoliday || visibleEntries.isEmpty))
-                                Padding(
-                                  padding: const EdgeInsets.only(bottom: 10),
-                                  child: InkWell(
+                                ),
+                                if (cardVisibility.showTodaySchedule) ...[
+                                  const SizedBox(height: 12),
+                                  InkWell(
                                     onTap: () => widget.onNavigate(
-                                      isExamWeekActive
+                                      (todayExams.isNotEmpty ||
+                                              isExamWeekActive)
                                           ? HomeTab.examSchedule
                                           : HomeTab.studentSchedule,
                                     ),
-                                    child: _ScheduleTile(
-                                      title: isExamWeekActive
-                                          ? 'No Class Today'
-                                          : isTodayHoliday
-                                          ? 'National Holiday'
-                                          : 'No Class Today',
-                                      subtitle: isExamWeekActive
-                                          ? examWeekStatus.subtitle
-                                          : isTodayHoliday
-                                          ? holidayStatus.displayNames
-                                          : 'Enjoy your day off.',
-                                      badge: isExamWeekActive
-                                          ? '--'
-                                          : isTodayHoliday
-                                          ? 'OFF'
-                                          : '--',
-                                      color: _HomeDashboardState._primary,
+                                    child: Row(
+                                      children: [
+                                        Expanded(
+                                          child: Text(
+                                            'Today is $today',
+                                            style: TextStyle(
+                                              fontSize: 16,
+                                              fontWeight: FontWeight.w600,
+                                              color: BracuPalette.textPrimary(
+                                                context,
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                        Text(
+                                          todayDate,
+                                          style: TextStyle(
+                                            fontSize: 16,
+                                            fontWeight: FontWeight.w600,
+                                            color: BracuPalette.textPrimary(
+                                              context,
+                                            ),
+                                          ),
+                                        ),
+                                      ],
                                     ),
                                   ),
-                                )
-                              else if (visibleEntries.isNotEmpty)
-                                ...visibleEntries
-                                    .take(3)
-                                    .map(
-                                      (entry) => Padding(
-                                        padding: const EdgeInsets.only(
-                                          bottom: 10,
-                                        ),
-                                        child: InkWell(
-                                          onTap: () => widget.onNavigate(
-                                            HomeTab.studentSchedule,
+                                  const SizedBox(height: 12),
+                                  if (todayExams.isNotEmpty)
+                                    ...todayExams
+                                        .take(3)
+                                        .map(
+                                          (exam) => Padding(
+                                            padding: const EdgeInsets.only(
+                                              bottom: 10,
+                                            ),
+                                            child: InkWell(
+                                              onTap: () => widget.onNavigate(
+                                                HomeTab.examSchedule,
+                                              ),
+                                              child: _ScheduleTile(
+                                                title:
+                                                    '${exam.courseCode} ${exam.type}',
+                                                subtitle: formatTimeRange(
+                                                  exam.startTime,
+                                                  exam.endTime,
+                                                ),
+                                                trailing: exam.room,
+                                                trailingSub: exam.faculties,
+                                                badge: formatSectionBadge(
+                                                  exam.sectionName,
+                                                ),
+                                                color:
+                                                    _HomeDashboardState._accent,
+                                                isHighlighted: false,
+                                              ),
+                                            ),
                                           ),
-                                          child: _ScheduleTile(
-                                            title: entry.courseCode,
-                                            subtitle: formatTimeRange(
-                                              entry.startTime,
-                                              entry.endTime,
+                                        ),
+                                  if (todayExams.isNotEmpty &&
+                                      visibleEntries.isNotEmpty)
+                                    const SizedBox(height: 10),
+                                  if (todayExams.isEmpty &&
+                                      (isTodayHoliday ||
+                                          visibleEntries.isEmpty))
+                                    Padding(
+                                      padding: const EdgeInsets.only(
+                                        bottom: 10,
+                                      ),
+                                      child: InkWell(
+                                        onTap: () => widget.onNavigate(
+                                          isExamWeekActive
+                                              ? HomeTab.examSchedule
+                                              : HomeTab.studentSchedule,
+                                        ),
+                                        child: _ScheduleTile(
+                                          title: isExamWeekActive
+                                              ? 'No Class Today'
+                                              : isTodayHoliday
+                                              ? 'National Holiday'
+                                              : 'No Class Today',
+                                          subtitle: isExamWeekActive
+                                              ? examWeekStatus.subtitle
+                                              : isTodayHoliday
+                                              ? holidayStatus.displayNames
+                                              : 'Enjoy your day off.',
+                                          badge: isExamWeekActive
+                                              ? '--'
+                                              : isTodayHoliday
+                                              ? 'OFF'
+                                              : '--',
+                                          color: _HomeDashboardState._primary,
+                                        ),
+                                      ),
+                                    )
+                                  else if (visibleEntries.isNotEmpty)
+                                    ...visibleEntries
+                                        .take(3)
+                                        .map(
+                                          (entry) => Padding(
+                                            padding: const EdgeInsets.only(
+                                              bottom: 10,
                                             ),
-                                            trailing: entry.roomNumber,
-                                            trailingSub: entry.faculties,
-                                            badge: formatSectionBadge(
-                                              entry.sectionName,
+                                            child: InkWell(
+                                              onTap: () => widget.onNavigate(
+                                                HomeTab.studentSchedule,
+                                              ),
+                                              child: _ScheduleTile(
+                                                title: entry.courseCode,
+                                                subtitle: formatTimeRange(
+                                                  entry.startTime,
+                                                  entry.endTime,
+                                                ),
+                                                trailing: entry.roomNumber,
+                                                trailingSub: entry.faculties,
+                                                badge: formatSectionBadge(
+                                                  entry.sectionName,
+                                                ),
+                                                color: _HomeDashboardState
+                                                    ._primary,
+                                                isHighlighted: false,
+                                              ),
                                             ),
-                                            color: _HomeDashboardState._primary,
-                                            isHighlighted: false,
+                                          ),
+                                        ),
+                                ],
+                                if (cardVisibility.showTodaySchedule &&
+                                    todayExams.isEmpty &&
+                                    visibleEntries.isEmpty &&
+                                    !isTodayHoliday &&
+                                    !isExamWeekActive)
+                                  const Padding(
+                                    padding: EdgeInsets.only(top: 8, bottom: 2),
+                                    child: _LoadingLine(),
+                                  ),
+                                if (cardVisibility.showRamadanCard && isRamadan)
+                                  Padding(
+                                    padding: const EdgeInsets.only(bottom: 8),
+                                    child: BracuCard(
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          if (nextCountdownTarget != null) ...[
+                                            _RamadanTopCountdown(
+                                              ramadanDay: ramadan.ramadanDay,
+                                              targetLabel: nextCountdownTarget,
+                                              targetTime:
+                                                  nextCountdownTarget == 'Sehri'
+                                                  ? ramadan.sehriEndsAt
+                                                  : ramadan.iftarAt,
+                                            ),
+                                            Divider(
+                                              height: 14,
+                                              thickness: 1,
+                                              color:
+                                                  BracuPalette.textSecondary(
+                                                    context,
+                                                  ).withValues(
+                                                    alpha:
+                                                        Theme.of(
+                                                              context,
+                                                            ).brightness ==
+                                                            Brightness.dark
+                                                        ? 0.20
+                                                        : 0.12,
+                                                  ),
+                                            ),
+                                          ],
+                                          if (ramadan.sehriEndsAt != null ||
+                                              ramadan.iftarAt != null) ...[
+                                            Row(
+                                              children: [
+                                                if (ramadan.sehriEndsAt != null)
+                                                  Expanded(
+                                                    child: _RamadanHeroTime(
+                                                      label: 'Sehri',
+                                                      value: BracuTime.format(
+                                                        ramadan.sehriEndsAt,
+                                                      ),
+                                                    ),
+                                                  ),
+                                                if (ramadan.sehriEndsAt !=
+                                                        null &&
+                                                    ramadan.iftarAt != null)
+                                                  const SizedBox(width: 10),
+                                                if (ramadan.iftarAt != null)
+                                                  Expanded(
+                                                    child: _RamadanHeroTime(
+                                                      label: 'Iftar',
+                                                      value: BracuTime.format(
+                                                        ramadan.iftarAt,
+                                                      ),
+                                                      alignRight: true,
+                                                    ),
+                                                  ),
+                                              ],
+                                            ),
+                                            const SizedBox(height: 2),
+                                          ],
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                if (cardVisibility.showQuickAccessSection) ...[
+                                  SizedBox(
+                                    height:
+                                        cardVisibility.showRamadanCard &&
+                                            isRamadan
+                                        ? 0
+                                        : 10,
+                                  ),
+                                  Row(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.center,
+                                    children: [
+                                      const Expanded(
+                                        child: _SectionTitle(
+                                          title: 'Quick Access',
+                                        ),
+                                      ),
+                                      InkWell(
+                                        borderRadius: BorderRadius.circular(8),
+                                        onTap: () async {
+                                          await InAppReviewPrompt.openStoreListing();
+                                        },
+                                        child: Padding(
+                                          padding: const EdgeInsets.symmetric(
+                                            horizontal: 6,
+                                            vertical: 2,
+                                          ),
+                                          child: Row(
+                                            mainAxisSize: MainAxisSize.min,
+                                            children: [
+                                              SizedBox(
+                                                width: 16,
+                                                child: Icon(
+                                                  Icons.star_border_rounded,
+                                                  size: 17,
+                                                  color:
+                                                      BracuPalette.textPrimary(
+                                                        context,
+                                                      ),
+                                                ),
+                                              ),
+                                              const SizedBox(width: 6),
+                                              Text(
+                                                'Rate',
+                                                softWrap: false,
+                                                style: TextStyle(
+                                                  fontSize: 16,
+                                                  fontWeight: FontWeight.w600,
+                                                  color:
+                                                      BracuPalette.textPrimary(
+                                                        context,
+                                                      ),
+                                                ),
+                                              ),
+                                            ],
                                           ),
                                         ),
                                       ),
-                                    ),
-                            ],
-                            if (cardVisibility.showTodaySchedule &&
-                                todayExams.isEmpty &&
-                                visibleEntries.isEmpty &&
-                                !isTodayHoliday &&
-                                !isExamWeekActive)
-                              const Padding(
-                                padding: EdgeInsets.only(top: 8, bottom: 2),
-                                child: _LoadingLine(),
-                              ),
-                            if (cardVisibility.showRamadanCard && isRamadan)
-                              Padding(
-                                padding: const EdgeInsets.only(bottom: 8),
-                                child: BracuCard(
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      if (nextCountdownTarget != null) ...[
-                                        _RamadanTopCountdown(
-                                          ramadanDay: ramadan.ramadanDay,
-                                          targetLabel: nextCountdownTarget,
-                                          targetTime:
-                                              nextCountdownTarget == 'Sehri'
-                                              ? ramadan.sehriEndsAt
-                                              : ramadan.iftarAt,
-                                        ),
-                                        Divider(
-                                          height: 14,
-                                          thickness: 1,
-                                          color:
-                                              BracuPalette.textSecondary(
-                                                context,
-                                              ).withValues(
-                                                alpha:
-                                                    Theme.of(
-                                                          context,
-                                                        ).brightness ==
-                                                        Brightness.dark
-                                                    ? 0.20
-                                                    : 0.12,
+                                      const SizedBox(width: 4),
+                                      InkWell(
+                                        borderRadius: BorderRadius.circular(8),
+                                        onTap: () async {
+                                          await SharePlus.instance.share(
+                                            ShareParams(
+                                              uri: Uri.parse(
+                                                'https://play.google.com/store/apps/details?id=com.sabbirba.preconnect',
                                               ),
-                                        ),
-                                      ],
-                                      if (ramadan.sehriEndsAt != null ||
-                                          ramadan.iftarAt != null) ...[
-                                        Row(
-                                          children: [
-                                            if (ramadan.sehriEndsAt != null)
-                                              Expanded(
-                                                child: _RamadanHeroTime(
-                                                  label: 'Sehri',
-                                                  value: BracuTime.format(
-                                                    ramadan.sehriEndsAt,
-                                                  ),
+                                              subject:
+                                                  'PreConnect • Prepare. Connect. Succeed.',
+                                            ),
+                                          );
+                                        },
+                                        child: Padding(
+                                          padding: const EdgeInsets.symmetric(
+                                            horizontal: 6,
+                                            vertical: 2,
+                                          ),
+                                          child: Row(
+                                            mainAxisSize: MainAxisSize.min,
+                                            children: [
+                                              SizedBox(
+                                                width: 16,
+                                                child: Icon(
+                                                  Icons.share_outlined,
+                                                  size: 14,
+                                                  color:
+                                                      BracuPalette.textPrimary(
+                                                        context,
+                                                      ),
                                                 ),
                                               ),
-                                            if (ramadan.sehriEndsAt != null &&
-                                                ramadan.iftarAt != null)
-                                              const SizedBox(width: 10),
-                                            if (ramadan.iftarAt != null)
-                                              Expanded(
-                                                child: _RamadanHeroTime(
-                                                  label: 'Iftar',
-                                                  value: BracuTime.format(
-                                                    ramadan.iftarAt,
-                                                  ),
-                                                  alignRight: true,
+                                              const SizedBox(width: 6),
+                                              Text(
+                                                'Share',
+                                                softWrap: false,
+                                                style: TextStyle(
+                                                  fontSize: 16,
+                                                  fontWeight: FontWeight.w600,
+                                                  color:
+                                                      BracuPalette.textPrimary(
+                                                        context,
+                                                      ),
                                                 ),
                                               ),
-                                          ],
+                                            ],
+                                          ),
                                         ),
-                                        const SizedBox(height: 2),
-                                      ],
+                                      ),
                                     ],
                                   ),
-                                ),
-                              ),
-                            if (cardVisibility.showQuickAccessSection) ...[
-                              SizedBox(
-                                height:
-                                    cardVisibility.showRamadanCard && isRamadan
-                                    ? 0
-                                    : 10,
-                              ),
-                              Row(
-                                crossAxisAlignment: CrossAxisAlignment.center,
-                                children: [
-                                  const Expanded(
-                                    child: _SectionTitle(title: 'Quick Access'),
-                                  ),
-                                  InkWell(
-                                    borderRadius: BorderRadius.circular(8),
-                                    onTap: () async {
-                                      await InAppReviewPrompt.openStoreListing();
-                                    },
-                                    child: Padding(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 6,
-                                        vertical: 2,
-                                      ),
-                                      child: Row(
-                                        mainAxisSize: MainAxisSize.min,
-                                        children: [
-                                          SizedBox(
-                                            width: 16,
-                                            child: Icon(
-                                              Icons.star_border_rounded,
-                                              size: 17,
-                                              color: BracuPalette.textPrimary(
-                                                context,
-                                              ),
-                                            ),
-                                          ),
-                                          const SizedBox(width: 6),
-                                          Text(
-                                            'Rate',
-                                            softWrap: false,
-                                            style: TextStyle(
-                                              fontSize: 16,
-                                              fontWeight: FontWeight.w600,
-                                              color: BracuPalette.textPrimary(
-                                                context,
-                                              ),
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                  ),
-                                  const SizedBox(width: 4),
-                                  InkWell(
-                                    borderRadius: BorderRadius.circular(8),
-                                    onTap: () async {
-                                      await SharePlus.instance.share(
-                                        ShareParams(
-                                          uri: Uri.parse(
-                                            'https://play.google.com/store/apps/details?id=com.sabbirba.preconnect',
-                                          ),
-                                          subject:
-                                              'PreConnect • Prepare. Connect. Succeed.',
-                                        ),
+                                  const SizedBox(height: 12),
+                                  LayoutBuilder(
+                                    builder: (context, constraints) {
+                                      return _buildQuickAccessGrid(
+                                        maxWidth: constraints.maxWidth,
                                       );
                                     },
-                                    child: Padding(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 6,
-                                        vertical: 2,
-                                      ),
-                                      child: Row(
-                                        mainAxisSize: MainAxisSize.min,
-                                        children: [
-                                          SizedBox(
-                                            width: 16,
-                                            child: Icon(
-                                              Icons.share_outlined,
-                                              size: 14,
-                                              color: BracuPalette.textPrimary(
-                                                context,
-                                              ),
-                                            ),
-                                          ),
-                                          const SizedBox(width: 6),
-                                          Text(
-                                            'Share',
-                                            softWrap: false,
-                                            style: TextStyle(
-                                              fontSize: 16,
-                                              fontWeight: FontWeight.w600,
-                                              color: BracuPalette.textPrimary(
-                                                context,
-                                              ),
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
                                   ),
                                 ],
-                              ),
-                              const SizedBox(height: 12),
-                              LayoutBuilder(
-                                builder: (context, constraints) {
-                                  return _buildQuickAccessGrid(
-                                    maxWidth: constraints.maxWidth,
-                                  );
-                                },
-                              ),
-                            ],
-                            const SizedBox(height: 12),
-                            if (data == null)
-                              const Padding(
-                                padding: EdgeInsets.only(bottom: 12),
-                                child: _LoadingLine(),
-                              ),
-                            BracuActionBannerCard(
-                              icon: null,
-                              title: 'Campus Map & Contacts',
-                              subtitle: 'Location and emergency contacts',
-                              iconColor: const Color(0xFF22B573),
-                              onTap: _openCampusMapSheet,
+                                const SizedBox(height: 12),
+                                if (data == null)
+                                  const Padding(
+                                    padding: EdgeInsets.only(bottom: 12),
+                                    child: _LoadingLine(),
+                                  ),
+                                BracuActionBannerCard(
+                                  icon: null,
+                                  title: 'Campus Map & Contacts',
+                                  subtitle: 'Location and emergency contacts',
+                                  iconColor: const Color(0xFF22B573),
+                                  onTap: _openCampusMapSheet,
+                                ),
+                                const SizedBox(height: 12),
+                                const _InlineBannerAd(),
+                              ],
                             ),
-                            const SizedBox(height: 12),
-                            const _InlineBannerAd(),
-                          ],
-                        ),
-                      );
-                    },
-                  ),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 

--- a/lib/pages/home_sections/home_dashboard_view.dart
+++ b/lib/pages/home_sections/home_dashboard_view.dart
@@ -5,6 +5,7 @@ extension _HomeDashboardView on _HomeDashboardState {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bgTop = isDark ? Colors.black : _HomeDashboardState._bgTop;
     final bgBottom = isDark ? Colors.black : _HomeDashboardState._bgBottom;
+    final showBlobs = _latestData?.cardVisibility.showDecorations ?? true;
 
     return Container(
       decoration: BoxDecoration(
@@ -17,7 +18,7 @@ extension _HomeDashboardView on _HomeDashboardState {
       child: SafeArea(
         child: Stack(
           children: [
-            if (_showBlobs)
+            if (showBlobs)
               Positioned(
                 top: -80,
                 right: -60,
@@ -26,7 +27,7 @@ extension _HomeDashboardView on _HomeDashboardState {
                   size: 200,
                 ),
               ),
-            if (_showBlobs)
+            if (showBlobs)
               Positioned(
                 bottom: -90,
                 left: -70,

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -4,7 +4,6 @@ import 'package:preconnect/api/app_preferences_store.dart';
 import 'package:preconnect/api/custom_schedules_service.dart';
 import 'package:preconnect/pages/captive_wifi.dart';
 import 'package:preconnect/pages/ui_kit.dart';
-import 'package:preconnect/tools/app_storage.dart';
 import 'package:preconnect/tools/preconnect_constants.dart';
 import 'package:preconnect/tools/quiet_mode_controller.dart';
 import 'package:preconnect/tools/token_storage.dart';
@@ -61,9 +60,6 @@ class _SettingsPageState extends State<SettingsPage>
     final appLockEnabled = await AppLockService().isEnabled();
     await QuietModeController.instance.load();
     final quietModeResult = await QuietModeController.instance.refresh();
-    AppStorage.instance.getBool("showdecorblobs").then((value) {
-      if (mounted) setState(() => _showDecorations = value ?? true);
-    });
     if (!mounted) return;
     setState(() {
       _showQuickAccessSection = visibility.showQuickAccessSection;
@@ -81,10 +77,6 @@ class _SettingsPageState extends State<SettingsPage>
     });
   }
 
-  Future<void> _storageSetShowDecorations(bool value) async {
-    await AppStorage.instance.setBool("showdecorblobs", value);
-  }
-
   Future<void> _setShowRamadanCard(bool value) async {
     await _setVisibility(
       label: 'Ramadan Times',
@@ -99,7 +91,7 @@ class _SettingsPageState extends State<SettingsPage>
       label: 'Show Decorations',
       value: value,
       applyLocal: () => _showDecorations = value,
-      persist: _storageSetShowDecorations,
+      persist: HomeCardPreferences.setShowDecorations,
     );
   }
 

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -64,6 +64,7 @@ class _SettingsPageState extends State<SettingsPage>
     setState(() {
       _showQuickAccessSection = visibility.showQuickAccessSection;
       _showRamadanCard = visibility.showRamadanCard;
+      _showDecorations = visibility.showDecorations;
       _showExamCountdownCard = visibility.showExamCountdownCard;
       _showTodaySchedule = visibility.showTodaySchedule;
       _appLockEnabled = appLockEnabled;

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -4,6 +4,7 @@ import 'package:preconnect/api/app_preferences_store.dart';
 import 'package:preconnect/api/custom_schedules_service.dart';
 import 'package:preconnect/pages/captive_wifi.dart';
 import 'package:preconnect/pages/ui_kit.dart';
+import 'package:preconnect/tools/app_storage.dart';
 import 'package:preconnect/tools/preconnect_constants.dart';
 import 'package:preconnect/tools/quiet_mode_controller.dart';
 import 'package:preconnect/tools/token_storage.dart';
@@ -25,6 +26,7 @@ class _SettingsPageState extends State<SettingsPage>
   bool _showRamadanCard = true;
   bool _showExamCountdownCard = true;
   bool _showTodaySchedule = true;
+  bool _showDecorations = true;
   bool _appLockEnabled = false;
   bool _showSupport = true;
   bool _quietModeEnabled = false;
@@ -59,6 +61,9 @@ class _SettingsPageState extends State<SettingsPage>
     final appLockEnabled = await AppLockService().isEnabled();
     await QuietModeController.instance.load();
     final quietModeResult = await QuietModeController.instance.refresh();
+    AppStorage.instance.getBool("showdecorblobs").then((value) {
+      if (mounted) setState(() => _showDecorations = value ?? true);
+    });
     if (!mounted) return;
     setState(() {
       _showQuickAccessSection = visibility.showQuickAccessSection;
@@ -76,12 +81,25 @@ class _SettingsPageState extends State<SettingsPage>
     });
   }
 
+  Future<void> _storageSetShowDecorations(bool value) async {
+    await AppStorage.instance.setBool("showdecorblobs", value);
+  }
+
   Future<void> _setShowRamadanCard(bool value) async {
     await _setVisibility(
       label: 'Ramadan Times',
       value: value,
       applyLocal: () => _showRamadanCard = value,
       persist: HomeCardPreferences.setShowRamadanCard,
+    );
+  }
+
+  Future<void> _setShowDecorations(bool value) async {
+    await _setVisibility(
+      label: 'Show Decorations',
+      value: value,
+      applyLocal: () => _showDecorations = value,
+      persist: _storageSetShowDecorations,
     );
   }
 
@@ -280,6 +298,22 @@ class _SettingsPageState extends State<SettingsPage>
                   subtitle: 'Show upcoming exam countdown',
                   value: _showExamCountdownCard,
                   onChanged: _setShowExamCountdownCard,
+                ),
+                Divider(
+                  height: 12,
+                  thickness: 1,
+                  color: BracuPalette.textSecondary(context).withValues(
+                    alpha: Theme.of(context).brightness == Brightness.dark
+                        ? 0.20
+                        : 0.12,
+                  ),
+                ),
+                _ToggleRow(
+                  title: 'Show Decorations',
+                  subtitle:
+                      'Display beautiful decorations on pages (restart required)',
+                  value: _showDecorations,
+                  onChanged: _setShowDecorations,
                 ),
                 Divider(
                   height: 12,

--- a/lib/pages/shared_widgets/ui_kit_components.dart
+++ b/lib/pages/shared_widgets/ui_kit_components.dart
@@ -1828,18 +1828,9 @@ class BracuPageScaffold extends StatefulWidget {
 }
 
 class _BracuPageScaffoldState extends State<BracuPageScaffold> {
-  bool _showBlobs = true;
   @override
   void initState() {
     super.initState();
-
-    AppStorage.instance.getBool("showdecorblobs").then((value) {
-      if (mounted) {
-        setState(() {
-          _showBlobs = value ?? true;
-        });
-      }
-    });
   }
 
   @override
@@ -1856,69 +1847,74 @@ class _BracuPageScaffoldState extends State<BracuPageScaffold> {
           ? Brightness.light
           : Brightness.dark,
     );
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-            colors: [
-              BracuPalette.bgTop(context),
-              BracuPalette.bgBottom(context),
-            ],
-          ),
-        ),
-        child: AnnotatedRegion<SystemUiOverlayStyle>(
-          value: overlayStyle,
-          child: Material(
-            type: MaterialType.transparency,
-            child: SafeArea(
-              child: Stack(
-                children: [
-                  if (_showBlobs)
-                    Positioned(
-                      top: -70,
-                      right: -60,
-                      child: DecorBlob(
-                        color: BracuPalette.primary.withValues(alpha: 0.12),
-                        size: 200,
-                      ),
-                    ),
-                  if (_showBlobs)
-                    Positioned(
-                      bottom: -80,
-                      left: -70,
-                      child: DecorBlob(
-                        color: BracuPalette.accent.withValues(alpha: 0.10),
-                        size: 220,
-                      ),
-                    ),
-                  Column(
-                    children: [
-                      Padding(
-                        padding: widget.showBack
-                            ? const EdgeInsets.fromLTRB(6, 12, 20, 8)
-                            : const EdgeInsets.fromLTRB(20, 12, 20, 8),
-                        child: _PageHeader(
-                          title: widget.title,
-                          subtitle: widget.subtitle,
-                          icon: widget.icon,
-                          actions: widget.actions,
-                          showMenu: widget.showMenu,
-                          showBack: widget.showBack,
-                          onHeaderTap: widget.onHeaderTap,
-                        ),
-                      ),
-                      Expanded(child: widget.body),
-                    ],
-                  ),
+    return ValueListenableBuilder(
+      valueListenable: HomeCardPreferences.decorationNotifier,
+      builder: (BuildContext context, enabled, Widget? child) {
+        return Scaffold(
+          backgroundColor: Colors.transparent,
+          body: Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  BracuPalette.bgTop(context),
+                  BracuPalette.bgBottom(context),
                 ],
               ),
             ),
+            child: AnnotatedRegion<SystemUiOverlayStyle>(
+              value: overlayStyle,
+              child: Material(
+                type: MaterialType.transparency,
+                child: SafeArea(
+                  child: Stack(
+                    children: [
+                      if (enabled)
+                        Positioned(
+                          top: -70,
+                          right: -60,
+                          child: DecorBlob(
+                            color: BracuPalette.primary.withValues(alpha: 0.12),
+                            size: 200,
+                          ),
+                        ),
+                      if (enabled)
+                        Positioned(
+                          bottom: -80,
+                          left: -70,
+                          child: DecorBlob(
+                            color: BracuPalette.accent.withValues(alpha: 0.10),
+                            size: 220,
+                          ),
+                        ),
+                      Column(
+                        children: [
+                          Padding(
+                            padding: widget.showBack
+                                ? const EdgeInsets.fromLTRB(6, 12, 20, 8)
+                                : const EdgeInsets.fromLTRB(20, 12, 20, 8),
+                            child: _PageHeader(
+                              title: widget.title,
+                              subtitle: widget.subtitle,
+                              icon: widget.icon,
+                              actions: widget.actions,
+                              showMenu: widget.showMenu,
+                              showBack: widget.showBack,
+                              onHeaderTap: widget.onHeaderTap,
+                            ),
+                          ),
+                          Expanded(child: widget.body),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/pages/shared_widgets/ui_kit_components.dart
+++ b/lib/pages/shared_widgets/ui_kit_components.dart
@@ -1852,66 +1852,77 @@ class _BracuPageScaffoldState extends State<BracuPageScaffold> {
       builder: (BuildContext context, enabled, Widget? child) {
         return Scaffold(
           backgroundColor: Colors.transparent,
-          body: Container(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [
-                  BracuPalette.bgTop(context),
-                  BracuPalette.bgBottom(context),
-                ],
-              ),
-            ),
-            child: AnnotatedRegion<SystemUiOverlayStyle>(
-              value: overlayStyle,
-              child: Material(
-                type: MaterialType.transparency,
-                child: SafeArea(
-                  child: Stack(
-                    children: [
-                      if (enabled)
-                        Positioned(
-                          top: -70,
-                          right: -60,
-                          child: DecorBlob(
-                            color: BracuPalette.primary.withValues(alpha: 0.12),
-                            size: 200,
-                          ),
+          body: ValueListenableBuilder(
+            valueListenable: HomeCardPreferences.decorationNotifier,
+            builder: (context, decorationsEnabled, child) {
+              return Container(
+                decoration: decorationsEnabled
+                    ? BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors: [
+                            BracuPalette.bgTop(context),
+                            BracuPalette.bgBottom(context),
+                          ],
                         ),
-                      if (enabled)
-                        Positioned(
-                          bottom: -80,
-                          left: -70,
-                          child: DecorBlob(
-                            color: BracuPalette.accent.withValues(alpha: 0.10),
-                            size: 220,
-                          ),
-                        ),
-                      Column(
+                      )
+                    : null,
+                child: AnnotatedRegion<SystemUiOverlayStyle>(
+                  value: overlayStyle,
+                  child: Material(
+                    type: MaterialType.transparency,
+                    child: SafeArea(
+                      child: Stack(
                         children: [
-                          Padding(
-                            padding: widget.showBack
-                                ? const EdgeInsets.fromLTRB(6, 12, 20, 8)
-                                : const EdgeInsets.fromLTRB(20, 12, 20, 8),
-                            child: _PageHeader(
-                              title: widget.title,
-                              subtitle: widget.subtitle,
-                              icon: widget.icon,
-                              actions: widget.actions,
-                              showMenu: widget.showMenu,
-                              showBack: widget.showBack,
-                              onHeaderTap: widget.onHeaderTap,
+                          if (enabled)
+                            Positioned(
+                              top: -70,
+                              right: -60,
+                              child: DecorBlob(
+                                color: BracuPalette.primary.withValues(
+                                  alpha: 0.12,
+                                ),
+                                size: 200,
+                              ),
                             ),
+                          if (enabled)
+                            Positioned(
+                              bottom: -80,
+                              left: -70,
+                              child: DecorBlob(
+                                color: BracuPalette.accent.withValues(
+                                  alpha: 0.10,
+                                ),
+                                size: 220,
+                              ),
+                            ),
+                          Column(
+                            children: [
+                              Padding(
+                                padding: widget.showBack
+                                    ? const EdgeInsets.fromLTRB(6, 12, 20, 8)
+                                    : const EdgeInsets.fromLTRB(20, 12, 20, 8),
+                                child: _PageHeader(
+                                  title: widget.title,
+                                  subtitle: widget.subtitle,
+                                  icon: widget.icon,
+                                  actions: widget.actions,
+                                  showMenu: widget.showMenu,
+                                  showBack: widget.showBack,
+                                  onHeaderTap: widget.onHeaderTap,
+                                ),
+                              ),
+                              Expanded(child: widget.body),
+                            ],
                           ),
-                          Expanded(child: widget.body),
                         ],
                       ),
-                    ],
+                    ),
                   ),
                 ),
-              ),
-            ),
+              );
+            },
           ),
         );
       },

--- a/lib/pages/shared_widgets/ui_kit_components.dart
+++ b/lib/pages/shared_widgets/ui_kit_components.dart
@@ -1801,7 +1801,7 @@ class BracuPalette {
   }
 }
 
-class BracuPageScaffold extends StatelessWidget {
+class BracuPageScaffold extends StatefulWidget {
   const BracuPageScaffold({
     super.key,
     required this.title,
@@ -1822,6 +1822,25 @@ class BracuPageScaffold extends StatelessWidget {
   final bool showMenu;
   final bool showBack;
   final VoidCallback? onHeaderTap;
+
+  @override
+  State<BracuPageScaffold> createState() => _BracuPageScaffoldState();
+}
+
+class _BracuPageScaffoldState extends State<BracuPageScaffold> {
+  bool _showBlobs = true;
+  @override
+  void initState() {
+    super.initState();
+
+    AppStorage.instance.getBool("showdecorblobs").then((value) {
+      if (mounted) {
+        setState(() {
+          _showBlobs = value ?? true;
+        });
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -1857,39 +1876,41 @@ class BracuPageScaffold extends StatelessWidget {
             child: SafeArea(
               child: Stack(
                 children: [
-                  Positioned(
-                    top: -70,
-                    right: -60,
-                    child: DecorBlob(
-                      color: BracuPalette.primary.withValues(alpha: 0.12),
-                      size: 200,
+                  if (_showBlobs)
+                    Positioned(
+                      top: -70,
+                      right: -60,
+                      child: DecorBlob(
+                        color: BracuPalette.primary.withValues(alpha: 0.12),
+                        size: 200,
+                      ),
                     ),
-                  ),
-                  Positioned(
-                    bottom: -80,
-                    left: -70,
-                    child: DecorBlob(
-                      color: BracuPalette.accent.withValues(alpha: 0.10),
-                      size: 220,
+                  if (_showBlobs)
+                    Positioned(
+                      bottom: -80,
+                      left: -70,
+                      child: DecorBlob(
+                        color: BracuPalette.accent.withValues(alpha: 0.10),
+                        size: 220,
+                      ),
                     ),
-                  ),
                   Column(
                     children: [
                       Padding(
-                        padding: showBack
+                        padding: widget.showBack
                             ? const EdgeInsets.fromLTRB(6, 12, 20, 8)
                             : const EdgeInsets.fromLTRB(20, 12, 20, 8),
                         child: _PageHeader(
-                          title: title,
-                          subtitle: subtitle,
-                          icon: icon,
-                          actions: actions,
-                          showMenu: showMenu,
-                          showBack: showBack,
-                          onHeaderTap: onHeaderTap,
+                          title: widget.title,
+                          subtitle: widget.subtitle,
+                          icon: widget.icon,
+                          actions: widget.actions,
+                          showMenu: widget.showMenu,
+                          showBack: widget.showBack,
+                          onHeaderTap: widget.onHeaderTap,
                         ),
                       ),
-                      Expanded(child: body),
+                      Expanded(child: widget.body),
                     ],
                   ),
                 ],

--- a/lib/tools/token_storage.dart
+++ b/lib/tools/token_storage.dart
@@ -199,6 +199,7 @@ class CoursePinStore {
 class HomeCardPreferences {
   HomeCardPreferences._();
 
+  static final decorationNotifier = ValueNotifier(true);
   static const String _showQuickAccessSectionKey =
       'home_show_quick_access_section';
   static const String _showRamadanCardKey = 'home_show_ramadan_card';
@@ -206,21 +207,28 @@ class HomeCardPreferences {
       'home_show_exam_countdown_card';
   static const String _showTodayScheduleKey = 'home_show_today_schedule';
   static const String _showSponsoredContentKey = 'home_show_sponsored_content';
+  static const String _showDecorations = 'home_show_decorations';
 
   static const HomeCardVisibility defaults = HomeCardVisibility(
     showQuickAccessSection: true,
     showRamadanCard: true,
     showExamCountdownCard: true,
+    showDecorations: true,
     showTodaySchedule: true,
     showSponsoredContent: true,
   );
 
   static Future<HomeCardVisibility> load() async {
     try {
+      bool showDecorations =
+          await AppStorage.instance.getBool(_showDecorations) ?? true;
+      decorationNotifier.value = showDecorations;
+
       return HomeCardVisibility(
         showQuickAccessSection:
             await AppStorage.instance.getBool(_showQuickAccessSectionKey) ??
             true,
+        showDecorations: showDecorations,
         showRamadanCard:
             await AppStorage.instance.getBool(_showRamadanCardKey) ?? true,
         showExamCountdownCard:
@@ -239,6 +247,13 @@ class HomeCardPreferences {
   static Future<void> setShowRamadanCard(bool value) async {
     try {
       await AppStorage.instance.setBool(_showRamadanCardKey, value);
+    } catch (_) {}
+  }
+
+  static Future<void> setShowDecorations(bool value) async {
+    try {
+      decorationNotifier.value = value;
+      await AppStorage.instance.setBool(_showDecorations, value);
     } catch (_) {}
   }
 
@@ -271,11 +286,13 @@ class HomeCardVisibility {
   const HomeCardVisibility({
     required this.showQuickAccessSection,
     required this.showRamadanCard,
+    required this.showDecorations,
     required this.showExamCountdownCard,
     required this.showTodaySchedule,
     required this.showSponsoredContent,
   });
 
+  final bool showDecorations;
   final bool showQuickAccessSection;
   final bool showRamadanCard;
   final bool showExamCountdownCard;


### PR DESCRIPTION
## tl;dr

This PR adds a new "Show Decorations" toggle which disables decorations on pages when turned off. May be useful for people who like minimalism

The toggle-able decorations include:

- The two decorative blobs which appear in the home dashboard and other subsequent pages.
- The gradient background in the light theme for the app (turns into white when the toggle is set to OFF).