### PR TITLE
feat: add Homebrew installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,6 @@ An initiative run by [BRAC University](https://bracu.ac.bd) students.
 A Flutter app for BRAC University students with SSO login and Connect API integration.
 The supported browser experience is the Chrome extension build.
 
-## Installation
-
-Installation is available for multiple platforms through:
-
-- Latest release assets (APK / AAB / Chrome extension / iOS / macOS): [GitHub Releases](https://github.com/sabbirba/preconnect/releases/latest)
-- Android: [Google Play Store](https://play.google.com/store/apps/details?id=com.sabbirba.preconnect)
-- macOS: Using [Homebrew](https://brew.sh):
-  ```bash
-  brew install hitblast/tap/preconnect
-  ```
-  Or, use GitHub Releases as mentioned before.
-
 ### Key features
 
 - Simple, predictable navigation
@@ -40,6 +28,18 @@ Installation is available for multiple platforms through:
 - Campus tools like bus routes, free labs, printer support, and map/contact access
 - Notifications, profile, degree progress, and student helpers
 - Offline-friendly, cache-first experience
+
+## Installation
+
+Installation is available for multiple platforms through:
+
+- Latest release assets (APK / AAB / Chrome extension / iOS / macOS): [GitHub Releases](https://github.com/sabbirba/preconnect/releases/latest)
+- Android: [Google Play Store](https://play.google.com/store/apps/details?id=com.sabbirba.preconnect)
+- macOS: Using [Homebrew](https://brew.sh):
+  ```bash
+  brew install hitblast/tap/preconnect
+  ```
+  Or, use GitHub Releases as mentioned before.
 
 ## Project Map
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ An initiative run by [BRAC University](https://bracu.ac.bd) students.
 A Flutter app for BRAC University students with SSO login and Connect API integration.
 The supported browser experience is the Chrome extension build.
 
+## Installation
+
+Installation is available for multiple platforms through:
+
+- Latest release assets (APK / AAB / Chrome extension / iOS / macOS): [GitHub Releases](https://github.com/sabbirba/preconnect/releases/latest)
+- Android: [Google Play Store](https://play.google.com/store/apps/details?id=com.sabbirba.preconnect)
+- macOS: Using [Homebrew](https://brew.sh):
+  ```bash
+  brew install hitblast/tap/preconnect
+  ```
+  Or, use GitHub Releases as mentioned before.
+
 ### Key features
 
 - Simple, predictable navigation
@@ -96,10 +108,6 @@ macos/               macOS shell
 web/                 Chrome extension shell
 assets/              Icons & SVGs
 ```
-
-## Download
-
-- Latest release assets (APK / AAB / Chrome extension / iOS / macOS): [GitHub Releases](https://github.com/sabbirba/preconnect/releases/latest)
 
 ## Getting Started
 


### PR DESCRIPTION
## tl;dr

This PR adds a new "Installation" section in the README of the project to notify the users of the potential installation methods at the very start of reading. It also adds a new macOS section exclusively for desktop users to conveniently install the app from their terminal.

## screenshot

<img width="1436" height="318" alt="Screenshot 2026-05-20 at 7 57 51 PM" src="https://github.com/user-attachments/assets/b7fd0273-7326-4cab-a0d3-26475bc83439" />
