### PR TITLE
bugfix: Multiple widgets with identical `GlobalKey` in calender & free labs pages, and more

### DIFF
--- a/lib/pages/calendar.dart
+++ b/lib/pages/calendar.dart
@@ -241,7 +241,6 @@ class _CalendarCard extends StatelessWidget {
         : item.sessionLabel;
 
     return BracuCard(
-      key: key,
       isHighlighted: false,
       highlightColor: BracuPalette.primary,
       child: Row(

--- a/lib/pages/free_labs.dart
+++ b/lib/pages/free_labs.dart
@@ -835,7 +835,6 @@ class _CompactRoomRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BracuCard(
-      key: key,
       isHighlighted: isHighlighted,
       highlightColor: BracuPalette.primary,
       child: InkWell(


### PR DESCRIPTION
## tl;dr

- [x] Fixes a bug which led to the calender and the free labs pages having multiple `BracuCard` widgets with the same `GlobalKey`.
