### PR TITLE
fix: JS interop HTTP client bug (Chrome Extension compilation failure) using a stub 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Fast, Calm Academic Companion App.
 An initiative run by [BRAC University](https://bracu.ac.bd) students.
 
 ![GitHub Release](https://img.shields.io/github/v/release/sabbirba/preconnect?label=latest%20version&&color=dark-green) ![License](https://img.shields.io/badge/license-GPL3.0-blue) ![Contributors](https://img.shields.io/github/contributors/sabbirba/preconnect?color=red&link=https%3A%2F%2Fgithub.com%2Fsabbirba%2Fpreconnect%2Fblob%2Fmain%2FCONTRIBUTING.md)
+![Discord](https://img.shields.io/discord/1506919568499539968?link=https%3A%2F%2Fdiscord.gg%2FQ6Wupddrj7)
 
 </div>
 

--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -3,7 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:preconnect/api/api_config.dart';
 import 'package:preconnect/api/auth_service.dart';
-import 'package:preconnect/tools/http_service.dart';
+import 'package:preconnect/tools/http/http_service.dart';
 import 'package:preconnect/tools/play_install_referrer.dart';
 import 'package:preconnect/tools/preconnect_constants.dart';
 import 'package:preconnect/tools/token_refresh_flow.dart';

--- a/lib/api/auth_service.dart
+++ b/lib/api/auth_service.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:preconnect/tools/http_service.dart';
+import 'package:preconnect/tools/http/http_service.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:preconnect/api/app_preferences_store.dart';
 import 'package:preconnect/api/api_config.dart';

--- a/lib/api/course_material_service.dart
+++ b/lib/api/course_material_service.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
-import 'package:preconnect/tools/http_service.dart';
+import 'package:preconnect/tools/http/http_service.dart';
 
 import 'package:preconnect/api/api_client.dart';
 import 'package:preconnect/api/api_config.dart';

--- a/lib/pages/devs.dart
+++ b/lib/pages/devs.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
-import 'package:preconnect/tools/http_service.dart';
+import 'package:preconnect/tools/http/http_service.dart';
 import 'package:preconnect/api/api_config.dart';
 import 'package:preconnect/api/api_client.dart';
 import 'package:preconnect/api/app_preferences_store.dart';

--- a/lib/pages/free_labs.dart
+++ b/lib/pages/free_labs.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:preconnect/tools/http_service.dart';
+import 'package:preconnect/tools/http/http_service.dart';
 import 'package:preconnect/api/api_config.dart';
 import 'package:preconnect/api/app_preferences_store.dart';
 import 'package:preconnect/api/seat_status_service.dart';

--- a/lib/pages/login.dart
+++ b/lib/pages/login.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
-import 'package:preconnect/tools/http_service.dart';
+import 'package:preconnect/tools/http/http_service.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_android/webview_flutter_android.dart';
 

--- a/lib/pages/wifi_printer.dart
+++ b/lib/pages/wifi_printer.dart
@@ -6,7 +6,7 @@ import 'dart:typed_data';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:preconnect/tools/http_service.dart';
+import 'package:preconnect/tools/http/http_service.dart';
 import 'package:dart_pdf_reader/dart_pdf_reader.dart';
 import 'package:preconnect/api/auth_service.dart';
 import 'package:preconnect/api/profile_service.dart';

--- a/lib/tools/captive_wifi_http_service.dart
+++ b/lib/tools/captive_wifi_http_service.dart
@@ -50,9 +50,8 @@ class CaptiveWifiHttpService {
     return null;
   }
 
-  Future<IoCompatibleClient> newClient() async {
-    final client = await IoCompatibleClient.create()
-      ..userAgent = kPreconnectUserAgent;
+  Future<HttpClient> newClient() async {
+    final client = HttpClient()..userAgent = kPreconnectUserAgent;
     client.connectionTimeout = _connectionTimeout;
     return client;
   }
@@ -72,7 +71,7 @@ class CaptiveWifiHttpService {
   }
 
   Future<bool> isValidatedViaProbe({
-    required IoCompatibleClient client,
+    required HttpClient client,
     required Map<String, Cookie> cookies,
     Uri? probeUri,
   }) async {
@@ -90,7 +89,7 @@ class CaptiveWifiHttpService {
   }
 
   Future<CaptiveWifiHttpResult> getWithRedirects({
-    required IoCompatibleClient client,
+    required HttpClient client,
     required Uri uri,
     required Map<String, Cookie> cookies,
   }) async {
@@ -134,7 +133,7 @@ class CaptiveWifiHttpService {
   }
 
   Future<CaptiveWifiHttpResult> postOnce({
-    required IoCompatibleClient client,
+    required HttpClient client,
     required Uri uri,
     required String body,
     required Map<String, Cookie> cookies,

--- a/lib/tools/captive_wifi_http_service.dart
+++ b/lib/tools/captive_wifi_http_service.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:preconnect/tools/android_network_assist.dart';
 import 'package:preconnect/tools/token_storage.dart';
-import 'package:rhttp/rhttp.dart';
 
 class CaptiveWifiHttpResult {
   const CaptiveWifiHttpResult({

--- a/lib/tools/holiday_status.dart
+++ b/lib/tools/holiday_status.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:preconnect/api/api_config.dart';
-import 'package:preconnect/tools/http_service.dart';
+import 'package:preconnect/tools/http/http_service.dart';
 
 typedef HolidayItem = ({String startDate, String endDate, String label});
 

--- a/lib/tools/http/http_client.dart
+++ b/lib/tools/http/http_client.dart
@@ -1,0 +1,3 @@
+export 'http_stub.dart'
+    if (dart.library.js_interop) 'http_web.dart'
+    if (dart.library.io) 'http_native.dart';

--- a/lib/tools/http/http_native.dart
+++ b/lib/tools/http/http_native.dart
@@ -1,0 +1,6 @@
+import 'package:http/http.dart' as http;
+import 'package:rhttp/rhttp.dart';
+
+http.Client createHttpClient() {
+  return RhttpCompatibleClient.createSync();
+}

--- a/lib/tools/http/http_service.dart
+++ b/lib/tools/http/http_service.dart
@@ -1,0 +1,7 @@
+import 'package:http/http.dart' as http;
+
+import 'http_client.dart';
+
+class HttpService {
+  static final http.Client client = createHttpClient();
+}

--- a/lib/tools/http/http_stub.dart
+++ b/lib/tools/http/http_stub.dart
@@ -1,0 +1,3 @@
+Never createHttpClient() {
+  throw UnsupportedError("Unsupported platform");
+}

--- a/lib/tools/http/http_web.dart
+++ b/lib/tools/http/http_web.dart
@@ -1,0 +1,5 @@
+import 'package:http/http.dart' as http;
+
+http.Client createHttpClient() {
+  return http.Client();
+}

--- a/lib/tools/http_service.dart
+++ b/lib/tools/http_service.dart
@@ -1,6 +1,0 @@
-import 'package:rhttp/rhttp.dart';
-import 'package:http/http.dart' as http;
-
-class HttpService {
-  static final http.Client client = RhttpCompatibleClient.createSync();
-}

--- a/lib/tools/ramadan_timing.dart
+++ b/lib/tools/ramadan_timing.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:preconnect/tools/http_service.dart';
+import 'package:preconnect/tools/http/http_service.dart';
 
 import 'package:preconnect/api/api_config.dart';
 import 'package:preconnect/tools/time_utils.dart';

--- a/lib/tools/token_refresh_flow.dart
+++ b/lib/tools/token_refresh_flow.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:preconnect/tools/http_service.dart';
+import 'package:preconnect/tools/http/http_service.dart';
 import 'package:preconnect/tools/web_extension_api_config.dart';
 
 enum TokenRefreshStatus { refreshed, invalidSession, retryableFailure }

--- a/lib/tools/token_storage.dart
+++ b/lib/tools/token_storage.dart
@@ -5,7 +5,7 @@ import 'package:flutter/foundation.dart'
     show ValueNotifier, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart' show TargetPlatform;
 import 'package:flutter/services.dart';
-import 'package:preconnect/tools/http_service.dart';
+import 'package:preconnect/tools/http/http_service.dart';
 
 import 'package:in_app_review/in_app_review.dart';
 import 'package:local_auth/local_auth.dart';


### PR DESCRIPTION
## tl;dr

[rhttp](https://codeberg.org/Tienisto/rhttp) does not compile natively to JS, so I've come up with a neat solution which switches to `http` whenever we're using Flutter's JS interop features (we use `tools/http/http_client.dart` to dynamically determine what lib we're using), and use `rhttp` for any other platform.

The only caveat, for now, is that the captive Wi-Fi has been reverted to using `HttpClient` since using `IoCompatibleClient` would not solve the JS compilation failure.
