### PR TITLE
fix: GitHub does not like `rhttp`'s HTTP stack

### DIFF
--- a/lib/pages/devs.dart
+++ b/lib/pages/devs.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
-import 'package:preconnect/tools/http/http_service.dart';
 import 'package:preconnect/api/api_config.dart';
 import 'package:preconnect/api/api_client.dart';
 import 'package:preconnect/api/app_preferences_store.dart';
@@ -960,8 +959,5 @@ Future<http.Response> _githubGet(Uri uri) async {
     }
   }
 
-  return HttpService.client.get(
-    uri,
-    headers: _githubHeadersWithToken(includeToken: false),
-  );
+  return http.get(uri, headers: _githubHeadersWithToken(includeToken: false));
 }

--- a/lib/pages/devs.dart
+++ b/lib/pages/devs.dart
@@ -953,10 +953,8 @@ Future<http.Response> _githubGet(Uri uri) async {
   final authenticated = token.isNotEmpty;
 
   if (authenticated) {
-    final response = await HttpService.client.get(
-      uri,
-      headers: _githubHeaders(),
-    );
+    // rhttp does weird things when used with GitHub APIs
+    final response = await http.get(uri, headers: _githubHeaders());
     if (response.statusCode != 401 && response.statusCode != 403) {
       return response;
     }

--- a/lib/tools/cached_image.dart
+++ b/lib/tools/cached_image.dart
@@ -6,6 +6,7 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:http/http.dart';
+import 'package:http/http.dart' as http;
 import 'package:preconnect/api/api_client.dart';
 import 'package:preconnect/tools/app_storage.dart';
 import 'package:preconnect/tools/app_paths.dart';
@@ -84,7 +85,13 @@ class _CachedImageState extends State<CachedImage> {
           'Accept': 'image/avif,image/webp,image/apng,image/*,*/*;q=0.8',
         };
         headers.addAll(compressionHeadersForUri(uri));
-        final response = await HttpService.client.get(uri, headers: headers);
+        final response =
+            uri.toString().contains(
+              "api.github.com",
+            ) // avoid rhttp if fetching from GitHub
+            ? await HttpService.client.get(uri, headers: headers)
+            : await http.get(uri, headers: headers);
+
         if (response.statusCode >= 200 && response.statusCode < 300) {
           return response.bodyBytes;
         }


### PR DESCRIPTION
## tl;dr

- [x] The "Devs" page now uses `http` as using `rhttp` for GitHub means tampering with a lot of different protocol-specific issues (HTTP/2, credential issues etc.) as in the current version of `rhttp` (0.17.0), these things are prominent in some platforms such as Android.
- [x] Image-fetching logic now prevents `rhttp` use when the URI contains GitHub's API endpoint.

This is more of a temporary aid than a permanent fix. Once this is resolved from `rhttp`'s side, I'd revert everything to using it as the primary client.