### PR TITLE
Feature: Time-Based Sorting of Seat Statuses & More

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ Use this guide when you want to build, test, or contribute to the app. You do no
 
 - Git
 - Rust (v1.80.0 or later)
+  > [!NOTE]
+  > Only the `minimal`-profile toolchain is necessary for this project as it does not require any debugging/linting features.
 - Flutter stable, using Dart from the Flutter SDK
 - Android Studio with Android SDK
 - An Android emulator or physical Android device

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -872,6 +872,7 @@ class _HomeData {
                 visibilityJson['showExamCountdownCard'] == true,
             showSponsoredContent:
                 visibilityJson['showSponsoredContent'] == true,
+            showCommunityLink: visibilityJson['showCommunityLink'] == true,
           )
         : HomeCardPreferences.defaults;
     final overridesJson = json['examOverrides'];

--- a/lib/pages/seat_status.dart
+++ b/lib/pages/seat_status.dart
@@ -84,6 +84,7 @@ class _SeatStatusPageState extends State<SeatStatusPage>
   bool _isDetailsRefreshing = false;
   bool _availableOnly = false;
   String _selectedDayFilter = '';
+  String _selectedTimeFilter = '';
   @override
   void initState() {
     super.initState();
@@ -118,6 +119,7 @@ class _SeatStatusPageState extends State<SeatStatusPage>
           _searchQuery,
           availableOnly: _availableOnly,
           dayFilter: _selectedDayFilter,
+          timeFilter: _selectedTimeFilter,
         ),
       );
     _isInitialLoading = false;
@@ -762,6 +764,7 @@ class _SeatStatusCardData {
     required this.remaining,
     required this.consumed,
     required this.total,
+    required this.timetables,
     required this.searchToken,
   });
 
@@ -777,6 +780,7 @@ class _SeatStatusCardData {
   final String courseType;
   final List<SeatStatusClassSchedule> classSchedule;
   final List<SeatStatusClassSchedule> labSchedule;
+  final List<SeatTimetable> timetables;
   final String labRoom;
   final String labCourseCode;
   final String labName;
@@ -822,6 +826,7 @@ class _SeatStatusCardData {
       consumed: consumed ?? this.consumed,
       total: total ?? this.total,
       searchToken: searchToken,
+      timetables: timetables,
     );
   }
 }

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -26,6 +26,7 @@ class _SettingsPageState extends State<SettingsPage>
   bool _showExamCountdownCard = true;
   bool _showTodaySchedule = true;
   bool _showDecorations = true;
+  bool _showCommunityLink = true;
   bool _appLockEnabled = false;
   bool _showSupport = true;
   bool _quietModeEnabled = false;
@@ -65,6 +66,7 @@ class _SettingsPageState extends State<SettingsPage>
       _showQuickAccessSection = visibility.showQuickAccessSection;
       _showRamadanCard = visibility.showRamadanCard;
       _showDecorations = visibility.showDecorations;
+      _showCommunityLink = visibility.showCommunityLink;
       _showExamCountdownCard = visibility.showExamCountdownCard;
       _showTodaySchedule = visibility.showTodaySchedule;
       _appLockEnabled = appLockEnabled;
@@ -90,10 +92,19 @@ class _SettingsPageState extends State<SettingsPage>
 
   Future<void> _setShowDecorations(bool value) async {
     await _setVisibility(
-      label: 'Show decorations',
+      label: 'Decorations',
       value: value,
       applyLocal: () => _showDecorations = value,
       persist: HomeCardPreferences.setShowDecorations,
+    );
+  }
+
+  Future<void> _setShowCommunityLink(bool value) async {
+    await _setVisibility(
+      label: 'Community Link',
+      value: value,
+      applyLocal: () => _showCommunityLink = value,
+      persist: HomeCardPreferences.setShowCommunityLink,
     );
   }
 
@@ -254,6 +265,14 @@ class _SettingsPageState extends State<SettingsPage>
 
   @override
   Widget build(BuildContext context) {
+    Divider divider = Divider(
+      height: 12,
+      thickness: 1,
+      color: BracuPalette.textSecondary(context).withValues(
+        alpha: Theme.of(context).brightness == Brightness.dark ? 0.20 : 0.12,
+      ),
+    );
+
     return BracuPageScaffold(
       title: 'Settings',
       subtitle: 'Customize',
@@ -303,77 +322,44 @@ class _SettingsPageState extends State<SettingsPage>
                   value: _showExamCountdownCard,
                   onChanged: _setShowExamCountdownCard,
                 ),
-                Divider(
-                  height: 12,
-                  thickness: 1,
-                  color: BracuPalette.textSecondary(context).withValues(
-                    alpha: Theme.of(context).brightness == Brightness.dark
-                        ? 0.20
-                        : 0.12,
-                  ),
-                ),
+                divider,
                 _ToggleRow(
-                  title: 'Show Decorations',
-                  subtitle: 'Display UI background decorations',
+                  title: 'Decorations',
+                  subtitle: 'Show UI background decorations',
                   value: _showDecorations,
                   onChanged: _setShowDecorations,
                 ),
-                Divider(
-                  height: 12,
-                  thickness: 1,
-                  color: BracuPalette.textSecondary(context).withValues(
-                    alpha: Theme.of(context).brightness == Brightness.dark
-                        ? 0.20
-                        : 0.12,
-                  ),
+                divider,
+                _ToggleRow(
+                  title: 'Community Link',
+                  subtitle: 'Show Discord banner on homepage',
+                  value: _showCommunityLink,
+                  onChanged: _setShowCommunityLink,
                 ),
+                divider,
                 _ToggleRow(
                   title: 'Ramadan Times',
                   subtitle: 'Show Sehri and Iftar times',
                   value: _showRamadanCard,
                   onChanged: _setShowRamadanCard,
                 ),
-                Divider(
-                  height: 12,
-                  thickness: 1,
-                  color: BracuPalette.textSecondary(context).withValues(
-                    alpha: Theme.of(context).brightness == Brightness.dark
-                        ? 0.20
-                        : 0.12,
-                  ),
-                ),
+                divider,
                 _ToggleRow(
                   title: 'Today\'s Schedule',
                   subtitle: 'Show today\'s class schedule',
                   value: _showTodaySchedule,
                   onChanged: _setShowTodaySchedule,
                 ),
-                Divider(
-                  height: 12,
-                  thickness: 1,
-                  color: BracuPalette.textSecondary(context).withValues(
-                    alpha: Theme.of(context).brightness == Brightness.dark
-                        ? 0.20
-                        : 0.12,
-                  ),
-                ),
+                divider,
                 _ToggleRow(
                   title: 'Quick Access',
                   subtitle: 'Show quick shortcuts on home',
                   value: _showQuickAccessSection,
                   onChanged: _setShowQuickAccessSection,
                 ),
-                Divider(
-                  height: 12,
-                  thickness: 1,
-                  color: BracuPalette.textSecondary(context).withValues(
-                    alpha: Theme.of(context).brightness == Brightness.dark
-                        ? 0.20
-                        : 0.12,
-                  ),
-                ),
+                divider,
                 _ToggleRow(
-                  title: 'Show Support',
+                  title: 'Support Content',
                   subtitle: 'Show support content and ads',
                   value: _showSupport,
                   onChanged: _setShowSupport,

--- a/lib/pages/shared_widgets/seat_status_methods.dart
+++ b/lib/pages/shared_widgets/seat_status_methods.dart
@@ -314,7 +314,7 @@ extension _SeatStatusPageStateMethods on _SeatStatusPageState {
         ? 'Any Time'
         : formatWeekdayTitle(_selectedTimeFilter);
 
-    List<SeatTimetable> assortedTimes = _visibleCards
+    List<SeatTimetable> assortedTimes = _cards
         .expand((card) => card.timetables)
         .toSet()
         .toList();
@@ -340,7 +340,7 @@ extension _SeatStatusPageStateMethods on _SeatStatusPageState {
             value: data.repr,
             label: data.repr,
             icon: Icons.calendar_today_outlined,
-            subtitle: 'Only $data',
+            subtitle: 'Only ${data.repr}',
           ),
         ),
       ],

--- a/lib/pages/shared_widgets/seat_status_methods.dart
+++ b/lib/pages/shared_widgets/seat_status_methods.dart
@@ -2,6 +2,25 @@
 
 part of 'package:preconnect/pages/seat_status.dart';
 
+class SeatTimetable {
+  final String startTime;
+  final String endTime;
+
+  const SeatTimetable({required this.startTime, required this.endTime});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SeatTimetable &&
+          startTime == other.startTime &&
+          endTime == other.endTime;
+
+  @override
+  int get hashCode => Object.hash(startTime, endTime);
+
+  String get repr => "${formatTime(startTime)} - ${formatTime(endTime)}";
+}
+
 extension _SeatStatusPageStateMethods on _SeatStatusPageState {
   _SeatStatusCardData _buildCardFromDetails({
     required int sectionId,
@@ -13,6 +32,13 @@ extension _SeatStatusPageStateMethods on _SeatStatusPageState {
     final facultySummaryLabel = seatStatusFacultySummaryLabel(details.faculty);
     final facultyDetailLabel = seatStatusFacultyDetailLabel(details.faculty);
     final facultySearchText = seatStatusFacultySearchText(details.faculty);
+    final timetables = details.sectionSchedule.classSchedules
+        .map(
+          (data) =>
+              SeatTimetable(startTime: data.startTime, endTime: data.endTime),
+        )
+        .toList();
+
     return _SeatStatusCardData(
       sectionId: sectionId,
       courseCode: details.courseCode,
@@ -37,6 +63,7 @@ extension _SeatStatusPageStateMethods on _SeatStatusPageState {
       finalExamDate: details.sectionSchedule.finalExamDate,
       finalExamStartTime: details.sectionSchedule.finalExamStartTime,
       finalExamEndTime: details.sectionSchedule.finalExamEndTime,
+      timetables: timetables,
       remaining: resolvedRemaining,
       consumed: resolvedConsumed,
       total: total,
@@ -233,6 +260,7 @@ extension _SeatStatusPageStateMethods on _SeatStatusPageState {
         children: [
           _buildAvailabilityFilterAction(),
           _buildDayFilterAction(context),
+          _buildTimeFilterAction(context),
         ],
       ),
     );
@@ -281,6 +309,45 @@ extension _SeatStatusPageStateMethods on _SeatStatusPageState {
     );
   }
 
+  Widget _buildTimeFilterAction(BuildContext context) {
+    final label = _selectedTimeFilter.isEmpty
+        ? 'Any Time'
+        : formatWeekdayTitle(_selectedTimeFilter);
+
+    List<SeatTimetable> assortedTimes = _visibleCards
+        .expand((card) => card.timetables)
+        .toSet()
+        .toList();
+
+    return BracuSelectDropdownChip<String>(
+      icon: Icons.calendar_today_outlined,
+      label: label,
+      selected: _selectedTimeFilter.isNotEmpty,
+      compact: true,
+      borderRadius: 999,
+      title: 'Filter by Time',
+      subtitle: 'Show seat status for a specific time',
+      selectedValue: _selectedTimeFilter,
+      options: <BracuSelectOption<String>>[
+        const BracuSelectOption<String>(
+          value: '',
+          label: 'Any Time',
+          icon: Icons.all_inclusive_rounded,
+          subtitle: 'Possible times',
+        ),
+        ...assortedTimes.map(
+          (data) => BracuSelectOption<String>(
+            value: data.repr,
+            label: data.repr,
+            icon: Icons.calendar_today_outlined,
+            subtitle: 'Only $data',
+          ),
+        ),
+      ],
+      onSelected: _setTimeFilter,
+    );
+  }
+
   void _setAvailableFilter(bool next) {
     if (next == _availableOnly) return;
     _refreshVisibleCards(availableOnly: next);
@@ -288,26 +355,35 @@ extension _SeatStatusPageStateMethods on _SeatStatusPageState {
 
   void _setDayFilter(String next) {
     if (next == _selectedDayFilter) return;
-    _refreshVisibleCards(dayFilter: next);
+    _refreshVisibleCards(dayFilter: next, timeFilter: _selectedTimeFilter);
+  }
+
+  void _setTimeFilter(String next) {
+    if (next == _selectedTimeFilter) return;
+    _refreshVisibleCards(dayFilter: _selectedDayFilter, timeFilter: next);
   }
 
   void _refreshVisibleCards({
     bool? availableOnly,
     String? dayFilter,
+    String? timeFilter,
     String? query,
   }) {
     final resolvedAvailableOnly = availableOnly ?? _availableOnly;
     final resolvedDayFilter = dayFilter ?? _selectedDayFilter;
+    final resolvedTimeFilter = timeFilter ?? _selectedTimeFilter;
     final resolvedQuery = query ?? _searchQuery;
     final nextVisible = _filterCards(
       _cards,
       resolvedQuery,
       availableOnly: resolvedAvailableOnly,
       dayFilter: resolvedDayFilter,
+      timeFilter: resolvedTimeFilter,
     );
     final filtersChanged =
         resolvedAvailableOnly != _availableOnly ||
         resolvedDayFilter != _selectedDayFilter ||
+        resolvedTimeFilter != _selectedTimeFilter ||
         resolvedQuery != _searchQuery;
     if (!filtersChanged &&
         !_areCardListsDifferent(_visibleCards, nextVisible)) {
@@ -316,6 +392,7 @@ extension _SeatStatusPageStateMethods on _SeatStatusPageState {
     setState(() {
       _availableOnly = resolvedAvailableOnly;
       _selectedDayFilter = resolvedDayFilter;
+      _selectedTimeFilter = resolvedTimeFilter;
       _searchQuery = resolvedQuery;
       _visibleCards
         ..clear()
@@ -329,6 +406,7 @@ extension _SeatStatusPageStateMethods on _SeatStatusPageState {
     String query, {
     required bool availableOnly,
     required String dayFilter,
+    required String timeFilter,
   }) {
     final q = query.trim().toLowerCase();
     return source.where((card) {
@@ -343,6 +421,11 @@ extension _SeatStatusPageStateMethods on _SeatStatusPageState {
           (entry) => normalizeWeekday(entry.day) == dayFilter,
         );
         if (!hasDay) return false;
+      }
+      if (timeFilter.isNotEmpty) {
+        final hasTime = card.timetables.any((data) => data.repr == timeFilter);
+
+        if (!hasTime) return false;
       }
       return true;
     }).toList();
@@ -362,6 +445,7 @@ extension _SeatStatusPageStateMethods on _SeatStatusPageState {
       _searchQuery,
       availableOnly: _availableOnly,
       dayFilter: _selectedDayFilter,
+      timeFilter: _selectedTimeFilter,
     );
     if (!mounted) return;
     final cardsChanged = _areCardListsDifferent(_cards, nextCards);

--- a/lib/pages/shared_widgets/ui_kit_dialogs.dart
+++ b/lib/pages/shared_widgets/ui_kit_dialogs.dart
@@ -683,7 +683,7 @@ Future<T?> showBracuSelectDropdown<T>(
                   ],
                 ),
                 child: ConstrainedBox(
-                  constraints: BoxConstraints(maxWidth: 200, maxHeight: 280),
+                  constraints: BoxConstraints(maxWidth: 215, maxHeight: 280),
                   child: Material(
                     color: cardColor,
                     borderRadius: BorderRadius.circular(999),

--- a/lib/pages/shared_widgets/ui_kit_dialogs.dart
+++ b/lib/pages/shared_widgets/ui_kit_dialogs.dart
@@ -682,44 +682,51 @@ Future<T?> showBracuSelectDropdown<T>(
                     ),
                   ],
                 ),
-                child: IntrinsicWidth(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: options.map((option) {
-                      final selected = option.value == selectedValue;
-                      return InkWell(
-                        onTap: () =>
-                            Navigator.of(dialogContext).pop(option.value),
-                        borderRadius: BorderRadius.circular(14),
-                        child: Padding(
-                          padding: optionPadding,
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Text(
-                                option.label,
-                                style: TextStyle(
-                                  color: textPrimary,
-                                  fontSize: optionFontSize,
-                                  fontWeight: selected
-                                      ? FontWeight.w800
-                                      : FontWeight.w600,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(maxWidth: 200, maxHeight: 280),
+                  child: Material(
+                    color: cardColor,
+                    borderRadius: BorderRadius.circular(999),
+                    child: ListView.builder(
+                      padding: EdgeInsets.zero,
+                      shrinkWrap: false,
+                      itemCount: options.length,
+                      itemBuilder: (context, index) {
+                        final option = options[index];
+                        final selected = option.value == selectedValue;
+
+                        return InkWell(
+                          onTap: () =>
+                              Navigator.of(dialogContext).pop(option.value),
+                          child: Padding(
+                            padding: optionPadding,
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  option.label,
+                                  style: TextStyle(
+                                    color: textPrimary,
+                                    fontSize: optionFontSize,
+                                    fontWeight: selected
+                                        ? FontWeight.w800
+                                        : FontWeight.w600,
+                                  ),
                                 ),
-                              ),
-                              if (selected) ...[
-                                const SizedBox(width: 8),
-                                Icon(
-                                  Icons.check_rounded,
-                                  size: 18,
-                                  color: BracuPalette.primary,
-                                ),
+                                if (selected) ...[
+                                  const SizedBox(width: 8),
+                                  Icon(
+                                    Icons.check_rounded,
+                                    size: 18,
+                                    color: BracuPalette.primary,
+                                  ),
+                                ],
                               ],
-                            ],
+                            ),
                           ),
-                        ),
-                      );
-                    }).toList(),
+                        );
+                      },
+                    ),
                   ),
                 ),
               ),

--- a/lib/pages/ui_kit.dart
+++ b/lib/pages/ui_kit.dart
@@ -993,7 +993,7 @@ class BracuCommunityLink extends StatelessWidget {
 
   final bool compact;
 
-  static const String _title = 'PreConnect Discord Server';
+  static const String _title = 'PreConnect Discord';
   static const String _subtitle =
       'Students, developers, and support in one place';
   static const String _label = 'Discord';
@@ -1001,7 +1001,7 @@ class BracuCommunityLink extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder<bool>(
-      valueListenable: HomeCardPreferences.sponsoredContentNotifier,
+      valueListenable: HomeCardPreferences.communityLinkNotifier,
       builder: (context, showSponsoredContent, _) {
         if (!showSponsoredContent) return const SizedBox.shrink();
 

--- a/lib/tools/token_storage.dart
+++ b/lib/tools/token_storage.dart
@@ -202,6 +202,8 @@ class HomeCardPreferences {
 
   static final decorationNotifier = ValueNotifier(true);
   static final sponsoredContentNotifier = ValueNotifier(true);
+  static final communityLinkNotifier = ValueNotifier(true);
+
   static const String showQuickAccessSectionKey =
       'home_show_quick_access_section';
   static const String showRamadanCardKey = 'home_show_ramadan_card';
@@ -210,6 +212,7 @@ class HomeCardPreferences {
   static const String showTodayScheduleKey = 'home_show_today_schedule';
   static const String showSponsoredContentKey = 'home_show_sponsored_content';
   static const String showDecorationsKey = 'home_show_decorations';
+  static const String showCommunityLinkKey = 'home_show_community_link';
 
   static const HomeCardVisibility defaults = HomeCardVisibility(
     showQuickAccessSection: true,
@@ -218,16 +221,21 @@ class HomeCardPreferences {
     showDecorations: true,
     showTodaySchedule: true,
     showSponsoredContent: true,
+    showCommunityLink: true,
   );
 
   static Future<HomeCardVisibility> load() async {
     try {
-      bool showDecorations =
+      final bool showDecorations =
           await AppStorage.instance.getBool(showDecorationsKey) ?? true;
-      final showSponsoredContent =
+      final bool showSponsoredContent =
           await AppStorage.instance.getBool(showSponsoredContentKey) ?? true;
+      final bool showCommunityLink =
+          await AppStorage.instance.getBool(showCommunityLinkKey) ?? true;
+
       decorationNotifier.value = showDecorations;
       sponsoredContentNotifier.value = showSponsoredContent;
+      communityLinkNotifier.value = showCommunityLink;
 
       return HomeCardVisibility(
         showQuickAccessSection:
@@ -241,6 +249,7 @@ class HomeCardPreferences {
         showTodaySchedule:
             await AppStorage.instance.getBool(showTodayScheduleKey) ?? true,
         showSponsoredContent: showSponsoredContent,
+        showCommunityLink: showCommunityLink,
       );
     } catch (_) {
       return defaults;
@@ -257,6 +266,13 @@ class HomeCardPreferences {
     try {
       decorationNotifier.value = value;
       await AppStorage.instance.setBool(showDecorationsKey, value);
+    } catch (_) {}
+  }
+
+  static Future<void> setShowCommunityLink(bool value) async {
+    try {
+      communityLinkNotifier.value = value;
+      await AppStorage.instance.setBool(showCommunityLinkKey, value);
     } catch (_) {}
   }
 
@@ -294,6 +310,7 @@ class HomeCardVisibility {
     required this.showExamCountdownCard,
     required this.showTodaySchedule,
     required this.showSponsoredContent,
+    required this.showCommunityLink,
   });
 
   final bool showDecorations;
@@ -302,6 +319,7 @@ class HomeCardVisibility {
   final bool showExamCountdownCard;
   final bool showTodaySchedule;
   final bool showSponsoredContent;
+  final bool showCommunityLink;
 }
 
 class InAppReviewPrompt {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      sha256: dad6bf6b9f4f378b0a69edbf42584d336efd1a9ce15deb1ba591cbb1b5ff440f
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
@@ -296,22 +296,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
-  glob:
-    dependency: transitive
-    description:
-      name: glob
-      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.3"
   hooks:
     dependency: transitive
     description:
       name: hooks
-      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
+      sha256: a41af4e8fc687cd6d33de9751eb936c8c0204ebe2bcb6c15ecf707504bf47f31
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.0"
   http:
     dependency: "direct main"
     description:
@@ -576,22 +568,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.2.0"
-  native_toolchain_c:
-    dependency: transitive
-    description:
-      name: native_toolchain_c
-      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.17.6"
   objective_c:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
+      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
       url: "https://pub.dev"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.1"
   open_filex:
     dependency: "direct main"
     description:
@@ -913,10 +897,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.29"
+    version: "6.3.30"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1033,10 +1017,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: a1fc9eb9248baa05dfc12ed5b66e377b3e23f095eec078e0371622b9033810d9
+      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.3.0"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
## tl;dr

- [x] Added a time-based filter for seat statuses. Uses hashing-based comparison and is constructed whenever each card is constructed. A new `SeatTimetable` object has been introduced to solve this problem by providing the necessary getters and overrides.
- [x] The community link is now controlled by a separate "Community Link" toggle in the settings menu, as keeping it under Support Content may make some users miss out on the Discord Server (opinionated change).
- [x] Minor UI adjustments, at best.
