### PR TITLE
Centralize Dependabot updates, auto-approve safe bumps, and refresh workflow versions/schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,79 @@
 version: 2
+
+multi-ecosystem-groups:
+  all-safe-dependencies:
+    schedule:
+      interval: "daily"
+      time: "00:00"
+      timezone: "Asia/Dhaka"
+    labels:
+      - "dependencies"
+
 updates:
   - package-ecosystem: "pub"
     directory: "/"
-    schedule:
-      interval: "daily"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "all-safe-dependencies"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "dart"
+    commit-message:
+      prefix: "chore(deps)"
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "all-safe-dependencies"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "all-safe-dependencies"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "ruby"
+    commit-message:
+      prefix: "chore(deps)"
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+
+  - package-ecosystem: "gradle"
+    directory: "/android"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "all-safe-dependencies"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "android"
+    commit-message:
+      prefix: "chore(deps)"
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -17,19 +17,23 @@ env:
 
 jobs:
   auto-merge:
-    name: Enable Auto Merge
+    name: Approve and Auto Merge
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'sabbirba/preconnect'
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
+
+      - name: Approve Dependabot PR
+        if: contains(fromJson('["version-update:semver-patch","version-update:semver-minor"]'), steps.metadata.outputs.update-type)
+        shell: bash
+        run: gh pr review "$PR_URL" --approve
 
       - name: Enable auto merge
         if: contains(fromJson('["version-update:semver-patch","version-update:semver-minor"]'), steps.metadata.outputs.update-type)
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
         shell: bash
-        run: |
-          gh pr merge "$PR_URL" --auto --squash
+        run: gh pr merge "$PR_URL" --auto --squash

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -25,10 +25,6 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
-concurrency:
-  group: pr-ci-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   format:
     name: Auto Format
@@ -72,7 +68,7 @@ jobs:
 
       - name: Upload Formatting Patch
         if: steps.patch.outputs.has_changes == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: pr-formatting-patch
           path: |
@@ -82,7 +78,7 @@ jobs:
 
       - name: Comment Formatting Needed
         if: steps.patch.outputs.has_changes == 'true' && github.event.pull_request.head.repo.full_name != github.repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const body = [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ on:
       - main
   workflow_dispatch:
   schedule:
-    # Promotion to Production releases every Friday at 10:00 PM (Bangladesh Time)
-    - cron: "00 16 * * 5"
+    # Promotion to Production runs every Friday at 12:00 AM Bangladesh time (Thursday 18:00 UTC).
+    - cron: "00 18 * * 4"
 
 permissions:
   contents: write
@@ -579,7 +579,7 @@ jobs:
           echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Download Android artifacts
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@v7.0.0
         continue-on-error: true
         with:
           name: android-artifacts

--- a/.github/workflows/store-promotion.yml
+++ b/.github/workflows/store-promotion.yml
@@ -2,8 +2,8 @@ name: Store Promotion
 
 on:
   schedule:
-    # Weekly Update on Thursday 10:00 PM Bangladesh Time.
-    - cron: "00 16 * * 4"
+    # Weekly store promotion runs every Thursday at 12:00 AM Bangladesh time (Wednesday 18:00 UTC).
+    - cron: "00 18 * * 3"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### Motivation
- Centralize dependency updates across multiple ecosystems under a single group and limit noisy updates to safe semver bumps.
- Automatically approve and auto-merge Dependabot PRs for semver patch/minor updates to reduce manual maintenance.
- Upgrade GitHub Action versions and adjust scheduled release/store promotion times to the desired Bangladesh timezone offsets.

### Description
- Updated `/.github/dependabot.yml` to add a `multi-ecosystem-groups` group and consolidated entries for `pub`, `github-actions`, `bundler`, and `gradle` with `patterns`, `multi-ecosystem-group`, `open-pull-requests-limit`, labels, `commit-message` prefix, and `allow` restricted to `version-update:semver-minor` and `version-update:semver-patch`.
- Modified `/.github/workflows/dependabot.yml` to rename the job to `Approve and Auto Merge`, restrict the job to Dependabot PRs in the repository, add `GITHUB_TOKEN`/`PR_URL` env, upgrade `dependabot/fetch-metadata` to `v3`, add an approval step using `gh pr review` conditioned on the update type, and run `gh pr merge --auto --squash` for allowed updates.
- Updated `/.github/workflows/pr-ci.yml` to bump `actions/upload-artifact` to `v7.0.1`, `actions/github-script` to `v8`, and remove the previous `concurrency` block used for the job.
- Adjusted schedules and action versions in CI workflows by changing cron timings in `/.github/workflows/release.yml` and `/.github/workflows/store-promotion.yml` to the new Bangladesh-time offsets and upgraded `actions/download-artifact` to `v7.0.0` in the release workflow.

### Testing
- No automated tests were executed as part of this change; modifications are limited to GitHub workflow and Dependabot configuration files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a279d57248321b38ddc7c5d765730)