### PR TITLE
Fix Dependabot multi-ecosystem group settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ multi-ecosystem-groups:
       timezone: "Asia/Dhaka"
     labels:
       - "dependencies"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
 
 updates:
   - package-ecosystem: "pub"
@@ -15,45 +18,33 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
-    open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "dart"
-    commit-message:
-      prefix: "chore(deps)"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
-    open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "github-actions"
-    commit-message:
-      prefix: "chore(deps)"
 
   - package-ecosystem: "bundler"
     directory: "/"
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
-    open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "ruby"
-    commit-message:
-      prefix: "chore(deps)"
 
   - package-ecosystem: "gradle"
     directory: "/android"
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
-    open-pull-requests-limit: 10
     labels:
       - "dependencies"
       - "android"
-    commit-message:
-      prefix: "chore(deps)"


### PR DESCRIPTION
### Motivation
- The Dependabot config duplicated `commit-message` and `open-pull-requests-limit` on each grouped update even though those options must be set on the multi-ecosystem group, causing invalid/ambiguous settings.
- Consolidating these settings to the `all-dependencies` group keeps the configuration correct and DRY for all grouped updates.

### Description
- Move `open-pull-requests-limit: 10` and `commit-message.prefix: "chore(deps)"` into `multi-ecosystem-groups.all-dependencies` in `.github/dependabot.yml`.
- Remove `open-pull-requests-limit` and `commit-message` keys from each `updates` entry that references `multi-ecosystem-group: "all-dependencies"`.
- The net change is a single-file update to `.github/dependabot.yml` that centralizes group-level settings.

### Testing
- Ran a Ruby YAML validation with `ruby -e 'require "yaml"; ...'` which parsed the file and asserted the group-level keys, and it succeeded.
- Ran `rg -n 'commit-message|open-pull-requests-limit|multi-ecosystem-group' .github/dependabot.yml` to confirm the keys are present only at the group level, and it reported the expected locations.
- Ran `git diff --check` to ensure no trailing whitespace or diff issues, and it returned clean results.
- A Python YAML parse attempt using `yaml.safe_load` failed in the environment due to a missing `yaml` module, not due to the config content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3bddd53c8321b51464bbae60e8d6)