### PR TITLE
Dependabot: target PRs to main and auto-merge Dependabot PRs targeting main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ multi-ecosystem-groups:
 updates:
   - package-ecosystem: "pub"
     directory: "/"
+    target-branch: "main"
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
@@ -24,6 +25,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "main"
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
@@ -33,6 +35,7 @@ updates:
 
   - package-ecosystem: "bundler"
     directory: "/"
+    target-branch: "main"
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
@@ -42,6 +45,7 @@ updates:
 
   - package-ecosystem: "gradle"
     directory: "/android"
+    target-branch: "main"
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,6 +2,8 @@ name: Dependabot
 
 on:
   pull_request_target:
+    branches:
+      - main
     types:
       - opened
       - synchronize
@@ -19,21 +21,15 @@ jobs:
   auto-merge:
     name: Approve and Auto Merge
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'sabbirba/preconnect'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.base.ref == 'main' && github.repository == 'sabbirba/preconnect'
     env:
       GITHUB_TOKEN: ${{ github.token }}
       PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3
-
       - name: Approve Dependabot PR
-        if: contains(fromJson('["version-update:semver-patch","version-update:semver-minor"]'), steps.metadata.outputs.update-type)
         shell: bash
         run: gh pr review "$PR_URL" --approve
 
       - name: Enable auto merge
-        if: contains(fromJson('["version-update:semver-patch","version-update:semver-minor"]'), steps.metadata.outputs.update-type)
         shell: bash
         run: gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
### Motivation

- Ensure Dependabot opens update PRs against the `main` branch and that the auto-merge workflow only acts on Dependabot PRs targeting `main`.
- Simplify the auto-merge approval flow so matching Dependabot PRs are approved and merged without depending on the update-type metadata.

### Description

- Add `target-branch: "main"` to the `pub`, `github-actions`, `bundler`, and `gradle` entries in `.github/dependabot.yml` so updates target `main`.
- Restrict the `pull_request_target` trigger in `.github/workflows/dependabot.yml` to `branches: [main]`.
- Tighten the auto-merge job `if` condition to require `github.event.pull_request.base.ref == 'main'` while still checking the Dependabot author and repository.
- Remove the `dependabot/fetch-metadata@v3` step and the conditional checks on metadata-driven `update-type`, making the workflow always approve and enable auto-merge for matching Dependabot PRs.

### Testing

- No automated tests were run for this repository configuration change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3da740fc83219257b63d4e16f985)