### PR TITLE
Simplify CI by removing retry loops and update Chrome web wasm flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,6 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-pending.outputs.should_run == 'true' }}
     needs: [detect-pending, prepare-version, create-release]
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow_failure }}
     timeout-minutes: 60
     permissions:
       contents: write
@@ -205,19 +204,15 @@ jobs:
           - os: ubuntu-latest
             platform: chrome_extension
             name: Chrome Extension
-            allow_failure: false
           - os: ubuntu-22.04
             platform: android
             name: Android
-            allow_failure: false
           - os: macos-latest
             platform: ios
             name: iOS
-            allow_failure: false
           - os: macos-latest
             platform: macos
             name: macOS
-            allow_failure: true
 
     steps:
       - name: Checkout
@@ -307,18 +302,7 @@ jobs:
 
       - name: Flutter Pub Get
         shell: bash
-        run: |
-          attempt=1
-          until [ $attempt -gt 3 ]; do
-            flutter pub get && break
-            echo "flutter pub get failed (attempt $attempt)."
-            attempt=$((attempt+1))
-            sleep $((5 * attempt))
-          done
-          if [ $attempt -gt 3 ]; then
-            echo "flutter pub get failed after 3 attempts."
-            exit 1
-          fi
+        run: flutter pub get
 
       - name: Release Env
         shell: bash
@@ -331,18 +315,7 @@ jobs:
       - name: Chrome Extension
         if: matrix.platform == 'chrome_extension'
         shell: bash
-        run: |
-          attempt=1
-          until [ $attempt -gt 3 ]; do
-            ./tool/build_chrome_extension.sh && break
-            echo "Chrome extension build failed (attempt $attempt)."
-            attempt=$((attempt+1))
-            sleep $((10 * attempt))
-          done
-          if [ $attempt -gt 3 ]; then
-            echo "Chrome extension build failed after 3 attempts."
-            exit 1
-          fi
+        run: ./tool/build_chrome_extension.sh
 
       - name: Chrome Package
         if: matrix.platform == 'chrome_extension'
@@ -403,18 +376,7 @@ jobs:
       - name: iOS App
         if: matrix.platform == 'ios'
         shell: bash
-        run: |
-          attempt=1
-          until [ $attempt -gt 3 ]; do
-            flutter build ios --release --no-codesign --tree-shake-icons --obfuscate --split-debug-info=build/symbols/ios --dart-define-from-file=.env && break
-            echo "iOS no-codesign build failed (attempt $attempt)."
-            attempt=$((attempt+1))
-            sleep $((10 * attempt))
-          done
-          if [ $attempt -gt 3 ]; then
-            echo "iOS no-codesign build failed after 3 attempts."
-            exit 1
-          fi
+        run: flutter build ios --release --no-codesign --tree-shake-icons --obfuscate --split-debug-info=build/symbols/ios --dart-define-from-file=.env
 
       - name: Detect Signing
         id: ios_signing
@@ -459,33 +421,12 @@ jobs:
           security list-keychains -s "$KEYCHAIN_PATH"
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
           printf '%s' "$IOS_PROFILE_BASE64" | base64 -d > "$HOME/Library/MobileDevice/Provisioning Profiles/profile.mobileprovision"
-          attempt=1
-          until [ $attempt -gt 3 ]; do
-            flutter build ipa --release --tree-shake-icons --obfuscate --split-debug-info=build/symbols/ios --dart-define-from-file=.env --export-options-plist=ios/ExportOptions.plist && break
-            echo "iOS signed IPA build failed (attempt $attempt)."
-            attempt=$((attempt+1))
-            sleep $((10 * attempt))
-          done
-          if [ $attempt -gt 3 ]; then
-            echo "iOS signed IPA build failed after 3 attempts."
-            exit 1
-          fi
+          flutter build ipa --release --tree-shake-icons --obfuscate --split-debug-info=build/symbols/ios --dart-define-from-file=.env --export-options-plist=ios/ExportOptions.plist
 
       - name: macOS App
         if: matrix.platform == 'macos'
         shell: bash
-        run: |
-          attempt=1
-          until [ $attempt -gt 3 ]; do
-            flutter build macos --release --tree-shake-icons --obfuscate --split-debug-info=build/symbols/macos --dart-define-from-file=.env && break
-            echo "macOS build failed (attempt $attempt)."
-            attempt=$((attempt+1))
-            sleep $((10 * attempt))
-          done
-          if [ $attempt -gt 3 ]; then
-            echo "macOS build failed after 3 attempts."
-            exit 1
-          fi
+        run: flutter build macos --release --tree-shake-icons --obfuscate --split-debug-info=build/symbols/macos --dart-define-from-file=.env
 
       - name: Android Package
         if: matrix.platform == 'android'
@@ -553,23 +494,12 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Assets
-        if: always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           if [ -d artifacts ] && find artifacts -type f -print -quit | grep -q .; then
-            attempt=1
-            until [ $attempt -gt 3 ]; do
-              gh release upload "${{ needs.create-release.outputs.release_tag }}" artifacts/* --clobber && break
-              echo "GitHub release asset upload failed for ${{ matrix.platform }} (attempt $attempt)."
-              attempt=$((attempt+1))
-              sleep $((8 * attempt))
-            done
-            if [ $attempt -gt 3 ]; then
-              echo "GitHub release asset upload failed for ${{ matrix.platform }} after 3 attempts."
-              exit 1
-            fi
+            gh release upload "${{ needs.create-release.outputs.release_tag }}" artifacts/* --clobber
           else
             echo "No packaged artifacts for ${{ matrix.platform }}."
           fi
@@ -599,7 +529,6 @@ jobs:
 
       - name: Download Android artifacts
         uses: actions/download-artifact@v8.0.1
-        continue-on-error: true
         with:
           name: android-artifacts
           path: artifacts/android

--- a/.github/workflows/store-promotion.yml
+++ b/.github/workflows/store-promotion.yml
@@ -125,18 +125,7 @@ jobs:
       - name: Flutter Pub Get
         if: matrix.run_chrome
         shell: bash
-        run: |
-          attempt=1
-          until [ $attempt -gt 3 ]; do
-            flutter pub get && break
-            echo "flutter pub get failed (attempt $attempt)."
-            attempt=$((attempt+1))
-            sleep $((5 * attempt))
-          done
-          if [ $attempt -gt 3 ]; then
-            echo "flutter pub get failed after 3 attempts."
-            exit 1
-          fi
+        run: flutter pub get
 
       - name: Chrome Env
         if: matrix.run_chrome
@@ -149,18 +138,7 @@ jobs:
       - name: Chrome Extension
         if: matrix.run_chrome
         shell: bash
-        run: |
-          attempt=1
-          until [ $attempt -gt 3 ]; do
-            ./tool/build_chrome_extension.sh && break
-            echo "Chrome extension build failed (attempt $attempt)."
-            attempt=$((attempt+1))
-            sleep $((10 * attempt))
-          done
-          if [ $attempt -gt 3 ]; then
-            echo "Chrome extension build failed after 3 attempts."
-            exit 1
-          fi
+        run: ./tool/build_chrome_extension.sh
 
       - name: Chrome Artifact
         if: matrix.run_chrome

--- a/tool/build_chrome_extension.sh
+++ b/tool/build_chrome_extension.sh
@@ -54,8 +54,8 @@ flutter build web \
   --release \
   --tree-shake-icons \
   --csp \
+  --no-wasm-dry-run \
   --no-web-resources-cdn \
-  --no-wasm \
   --dart-define-from-file="${ENV_FILE}" \
   --dart-define="APP_VERSION=${APP_VERSION}" \
   --dart-define="APP_BUILD_NUMBER=${APP_BUILD_NUMBER}" \


### PR DESCRIPTION
### Motivation
- Remove numerous ad-hoc retry loops and permissive failure settings in CI to make job outcomes deterministic and easier to reason about.
- Surface real failures in build and publish steps by removing `continue-on-error`/`if: always()` and matrix `allow_failure` entries.
- Fix Chrome extension web build behavior by adjusting the wasm-related Flutter flags to avoid dry-run issues.

### Description
- Replaced multi-attempt retry wrappers for `flutter pub get`, `./tool/build_chrome_extension.sh`, `flutter build ios`, `flutter build macos`, and GitHub release asset uploads with single-run invocations.
- Removed `continue-on-error: ${{ matrix.allow_failure }}` and `allow_failure` matrix entries so build matrix failures report immediately, and removed `continue-on-error: true` from an artifacts download step.
- Removed `if: always()` from the Upload Assets step and simplified the `gh release upload` invocation (no retry loops).
- Updated `tool/build_chrome_extension.sh` to add `--no-wasm-dry-run` and remove the `--no-wasm` flag on the Flutter web build.

### Testing
- No automated unit or integration tests were modified or executed as part of this change.
- CI workflow changes have not been run here; validation should occur when the GitHub Actions workflows are executed on the next run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b30b584388321b715a989ccc4b4b4)